### PR TITLE
Bump Iris 4.4.0

### DIFF
--- a/opam
+++ b/opam
@@ -13,5 +13,5 @@ install: [make "install"]
 description: "Iris Ora"
 remove: ["rm" "-rf" "'%{lib}%/coq/user-contrib/iris_ora"]
 depends: [
-  "coq-iris" { = "4.3.0" }
+  "coq-iris" { >= "4.3.0" }
 ]

--- a/opam
+++ b/opam
@@ -13,5 +13,5 @@ install: [make "install"]
 description: "Iris Ora"
 remove: ["rm" "-rf" "'%{lib}%/coq/user-contrib/iris_ora"]
 depends: [
-  "coq-iris" { >= "4.3.0" }
+  "coq-iris" { = "4.4.0" }
 ]

--- a/theories/algebra/agree.v
+++ b/theories/algebra/agree.v
@@ -193,7 +193,7 @@ Next Obligation.
   apply (agree_map_ext _)=>y; apply oFunctor_map_compose.
 Qed.
 
-#[export] Instance agreeRF_contractive F :
+#[export] Instance agreeRF_contractive {SI : sidx} F :
   oFunctorContractive F → OrarFunctorContractive (agreeRF F).
 Proof.
   intros ? A1 ? A2 ? B1 ? B2 ? n ???; simpl.

--- a/theories/algebra/agree.v
+++ b/theories/algebra/agree.v
@@ -161,10 +161,10 @@ Qed.
 
 End agree.
 
-Arguments agreeR : clear implicits.
+Arguments agreeR {_} _.
 
 Section agree_map.
-  Context {A B : ofe} (f : A → B) `{Hf: NonExpansive f}.
+  Context {SI: sidx} {A B : ofe} (f : A → B) `{Hf: NonExpansive f}.
 
   Global Instance agree_map_morphism : OraMorphism (agree_map f).
   Proof using Hf.
@@ -177,19 +177,19 @@ Section agree_map.
   Qed.
 End agree_map.
 
-Program Definition agreeRF (F : oFunctor) : OrarFunctor := {|
+Program Definition agreeRF {SI : sidx} (F : oFunctor) : OrarFunctor := {|
   orarFunctor_car A _ B _ := agreeR (oFunctor_car F A B);
   orarFunctor_map A1 _ A2 _ B1 _ B2 _ fg := agreeO_map (oFunctor_map F fg)
 |}.
 Next Obligation.
-  intros ? A1 ? A2 ? B1 ? B2 ? n ???; simpl. by apply agreeO_map_ne, oFunctor_map_ne.
+  intros ?? A1 ? A2 ? B1 ? B2 ? n ???; simpl. by apply agreeO_map_ne, oFunctor_map_ne.
 Qed.
 Next Obligation.
-  intros F A ? B ? x; simpl. rewrite -{2}(agree_map_id x).
+  intros ? F A ? B ? x; simpl. rewrite -{2}(agree_map_id x).
   apply (agree_map_ext _)=>y. by rewrite oFunctor_map_id.
 Qed.
 Next Obligation.
-  intros F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x; simpl. rewrite -agree_map_compose.
+  intros ? F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x; simpl. rewrite -agree_map_compose.
   apply (agree_map_ext _)=>y; apply oFunctor_map_compose.
 Qed.
 

--- a/theories/algebra/agree.v
+++ b/theories/algebra/agree.v
@@ -9,7 +9,7 @@ Local Coercion agree_car : agree >-> list.
 
 Section agree.
 Local Set Default Proof Using "Type".
-Context {A : ofe}.
+Context {SI : sidx} {A : ofe}.
 Implicit Types a b : A.
 Implicit Types x y : agree A.
 
@@ -103,9 +103,9 @@ Proof.
   - intros n x y Hx Hyx. exists x; split.
     + by apply agree_dist_orderN.
     + symmetry. eapply agree_order_dist; eauto.
-  - intros n x y. intros Hxy a Ha.
+  - intros n n' x y. intros Hxy Hn a Ha.
     destruct (Hxy _ Ha) as [z [Hz1 Hz2]].
-    eexists z; split; auto. by apply dist_S.
+    eexists z; split; auto. eauto using dist_le.
   - intros n x x' y Hxx' a Ha.
     apply elem_of_app in Ha. destruct Ha as [Ha|Ha].
     + destruct (Hxx' _ Ha) as [z [Hz1 Hz2]].

--- a/theories/algebra/auth.v
+++ b/theories/algebra/auth.v
@@ -2,7 +2,7 @@ From iris.algebra Require Import proofmode_classes big_op auth.
 From iris_ora.algebra Require Export view.
 From iris.prelude Require Import options.
 
-Lemma auth_view_rel_order : ∀ {A : uora} (H : ∀n (x y : A), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y) n (a x y : A),
+Lemma auth_view_rel_order : ∀ {SI : sidx} {A : uora} (H : ∀n (x y : A), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y) n (a x y : A),
   x ≼ₒ{n} y → auth_view_rel n a y → auth_view_rel n a x.
 Proof.
   inversion 3; split=> //.
@@ -11,10 +11,10 @@ Proof.
   eapply (cmra_validN_includedN(A:=A)); done.
 Qed.
 
-Definition authR (A : uora) (H : ∀n (x y : A), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y) : ora := view.viewR (A:=A) (B:=A) auth_view_rel (auth_view_rel_order H).
-Definition authUR (A : uora) (H : ∀n (x y : A), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y) : uora :=
+Definition authR {SI : sidx} (A : uora) (H : ∀n (x y : A), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y) : ora := view.viewR (A:=A) (B:=A) auth_view_rel (auth_view_rel_order H).
+Definition authUR {SI : sidx} (A : uora) (H : ∀n (x y : A), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y) : uora :=
   (Uora' (auth A) (ofe_mixin (authO A)) (cmra_mixin (iris.algebra.auth.authR A)) (ora_mixin (authR A H)) (view_ucmra_mixin auth_view_rel) (view_uora_mixin auth_view_rel)).
 
-Lemma auth_frag_core_id {A : uora} (a : A) (H : ∀n (x y : A), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y) :
+Lemma auth_frag_core_id {SI : sidx} {A : uora} (a : A) (H : ∀n (x y : A), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y) :
   OraCoreId a → OraCoreId(A := authR A H) (◯ a).
 Proof. rewrite /auth_frag. apply _. Qed.

--- a/theories/algebra/dfrac.v
+++ b/theories/algebra/dfrac.v
@@ -6,7 +6,7 @@ Local Arguments op _ _ _ !_ /.
 Local Arguments pcore _ _ !_ /.
 
 Section ora.
-
+  Context {SI : sidx}.
   Local Instance dfrac_order : OraOrder dfrac := λ a b, a = b ∨ a ⋅ DfracDiscarded = b.
 
   Local Instance discard_increasing : Increasing DfracDiscarded.

--- a/theories/algebra/excl.v
+++ b/theories/algebra/excl.v
@@ -3,7 +3,7 @@ From iris_ora.algebra Require Export ora.
 From iris.prelude Require Import options.
 
 Section excl.
-Context {A : ofe}.
+Context {SI: sidx} {A : ofe}.
 
 Instance excl_orderN : OraOrderN (excl A) := dist.
 Instance excl_order : OraOrder (excl A) := equiv.
@@ -22,9 +22,9 @@ Qed.
 
 End excl.
 
-Canonical Structure exclR (A : ofe) := Ora (excl A) (@excl_ora_mixin A).
+Canonical Structure exclR {SI: sidx} (A : ofe) := Ora (excl A) (@excl_ora_mixin _ A).
 
-#[export] Instance excl_ora_discrete A : OfeDiscrete A → OraDiscrete (exclR A).
+#[export] Instance excl_ora_discrete {SI: sidx} (A : ofe) : OfeDiscrete A → OraDiscrete (exclR A).
 Proof.
   intros (? & ?)%excl_cmra_discrete.
   constructor; done.

--- a/theories/algebra/excl.v
+++ b/theories/algebra/excl.v
@@ -14,7 +14,7 @@ Proof.
   - intros ???? Hv Ho.
     by rewrite -Ho in Hv; apply exclusiveN_r in Hv.
   - eauto.
-  - apply dist_S.
+  - apply dist_le.
   - by intros ???? ->.
   - apply equiv_dist.
   - inversion 1.

--- a/theories/algebra/excl_auth.v
+++ b/theories/algebra/excl_auth.v
@@ -2,12 +2,12 @@ From iris.algebra.lib Require Export excl_auth.
 From iris_ora.algebra Require Export excl auth.
 From iris.prelude Require Import options.
 
-Lemma excl_rel_order : ∀ {A : ofe} n (x y : optionUR (exclR A)), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y.
+Lemma excl_rel_order : ∀ {SI : sidx} {A : ofe} n (x y : optionUR (exclR A)), ✓{n} y → x ≼ₒ{n} y → x ≼{n} y.
 Proof.
-  intros ????? [(-> & ?) | (? & ? & -> & -> & H)]%option_orderN'.
+  intros ?????? [(-> & ?) | (? & ? & -> & -> & H)]%option_orderN'.
   - rewrite option_includedN; auto.
   - rewrite option_includedN; eauto 7.
 Qed.
 
-Definition excl_authR (A : ofe) := authR _ (@excl_rel_order A).
-Definition excl_authUR (A : ofe) := authUR _ (@excl_rel_order A).
+Definition excl_authR {SI : sidx} (A : ofe) := authR _ (@excl_rel_order _ A).
+Definition excl_authUR {SI : sidx} (A : ofe) := authUR _ (@excl_rel_order _ A).

--- a/theories/algebra/ext_order.v
+++ b/theories/algebra/ext_order.v
@@ -4,7 +4,7 @@ Require Import iris_ora.algebra.ora.
 (* inclusion order *)
 Section incl.
 
-Context {A : cmra} `{CmraTotal A}.
+Context {SI : sidx} `{A : !cmra} `{!CmraTotal A}.
 
 Instance incl_orderN : OraOrderN A := includedN.
 Instance incl_order : OraOrder A := λ x y, ∀n, x ≼{n} y.
@@ -30,7 +30,7 @@ Proof.
     exists z; rewrite Heq; split; [eexists|]; eauto.
   - intros ??? ->.
     exists (core y); by rewrite cmra_core_r.
-  - intros; by apply cmra_includedN_S.
+  - intros; eapply cmra_includedN_le; eauto.
   - intros; by apply cmra_monoN_r.
   - intros; by eapply cmra_validN_includedN.
   - intros ??? Hcore.
@@ -90,7 +90,7 @@ Section flat.
 
 (* This works, but only for very restricted algebras. *)
 
-Context {A : ucmra} (core_unit : forall (a : A), core a ≡ ε) {discrete_unit : Discrete (ε : A)}.
+Context {SI : sidx} {A : ucmra} (core_unit : forall (a : A), core a ≡ ε) {discrete_unit : Discrete (ε : A)}.
 
 Instance flat_orderN : OraOrderN A := dist.
 Instance flat_order : OraOrder A := equiv.
@@ -117,7 +117,7 @@ Proof.
     eexists _, _; split; last done.
     by rewrite Heq1.
   - eauto.
-  - apply dist_S.
+  - apply dist_le.
   - by intros ???? ->.
   - by intros ???? ->.
   - apply equiv_dist.
@@ -140,7 +140,7 @@ End flat.
 
 Section positive.
 
-Context {A : cmra} (positive : forall (a : A), ~a ≡ a ⋅ a).
+Context {SI : sidx} {A : cmra} (positive : forall (a : A), ~a ≡ a ⋅ a).
 
 Lemma coreless : forall (a : A), pcore a = None.
 Proof.
@@ -169,7 +169,7 @@ Proof.
     eexists _, _; split; last done.
     by rewrite Heq1.
   - eauto.
-  - apply dist_S.
+  - apply dist_le.
   - by intros ???? ->.
   - by intros ???? ->.
   - apply equiv_dist.
@@ -179,9 +179,9 @@ Qed.
 
 Local Canonical Structure positiveR : ora := Ora A positive_ora_mixin.
 
-#[export] Instance positive_discrete `{CmraDiscrete A} : OraDiscrete positiveR.
+#[export] Instance positive_discrete `{CmraDiscrete0: !CmraDiscrete A} : OraDiscrete positiveR.
 Proof.
-  destruct H; constructor; done.
+  destruct CmraDiscrete0; constructor; done.
 Qed.
 
 End positive.

--- a/theories/algebra/frac_auth.v
+++ b/theories/algebra/frac_auth.v
@@ -7,7 +7,7 @@ From iris.prelude Require Import options.
    it's sufficient to define it as an inclR wrapper over a standard cmra. *)
 Section frac_auth.
 
-Context (A : cmra).
+Context {SI : sidx} (A : cmra).
 
 Canonical Structure frac_authR := inclR (frac_authR A).
 
@@ -22,7 +22,7 @@ Canonical Structure frac_authUR := Uora frac_authR (ucmra_mixin (frac_authUR A))
 
 End frac_auth.
 
-Lemma frac_auth_frag_op : forall {A : cmra} (q1 q2 : Qp) (a1 a2 : A),
+Lemma frac_auth_frag_op : forall {SI : sidx} {A : cmra} (q1 q2 : Qp) (a1 a2 : A),
   ◯F{q1 + q2} (a1 ⋅ a2) ≡ ◯F{q1} a1 ⋅ ◯F{q2} a2.
 Proof.
   intros; apply frac_auth_frag_op.

--- a/theories/algebra/functions.v
+++ b/theories/algebra/functions.v
@@ -4,7 +4,7 @@ From iris_ora.algebra Require Export ora.
 From iris.prelude Require Import options.
 
 Section ora.
-  Context {A : Type} `{Hfin : Finite A} {B : A → uora}.
+  Context {SI : sidx} {A : Type} `{Hfin : Finite A} {B : A → uora}.
   Implicit Types x : A.
   Implicit Types f g : discrete_fun B.
 

--- a/theories/algebra/gmap.v
+++ b/theories/algebra/gmap.v
@@ -134,14 +134,14 @@ Proof.
     eexists; split; [constructor; reflexivity|].
     inversion Hcx as [?? Heq|]; subst.
     intros i.
-    Fail rewrite -Heq. (* FIXME *)
-    (* rewrite -Heq !lookup_omap lookup_op.
+    change (Oraorder ((cx !! i) : optionR A) (omap pcore (x ⋅ y) !! i)).
+    eapply ora_order_proper; [symmetry; apply Heq | reflexivity |].
+    rewrite !lookup_omap lookup_op.
     edestruct (ora_pcore_order_op (x !! i)) as (? & Hcore & ?).
     { constructor; reflexivity. }
     inversion Hcore as [?? Hxy|]; subst.
     by rewrite Hxy.
-Qed. *)
-Admitted.
+Qed.
 Canonical Structure gmapR : ora := Ora (gmap K A) gmap_ora_mixin.
 
 Global Instance gmap_ora_discrete : OraDiscrete A → OraDiscrete gmapR.

--- a/theories/algebra/gmap.v
+++ b/theories/algebra/gmap.v
@@ -118,8 +118,13 @@ Proof.
         destruct (y !! i) eqn: Hy; rewrite Hy in Hord |- *; done.
   - intros ?????.
     apply (@ora_dist_orderN _ (optionR A)); auto.
-  - intros ??? Hord i.
-    apply (@ora_orderN_S _ (optionR A)), Hord.
+  - intros ??? ? Hord ? ?.
+    rewrite /OraorderN /gmap_orderN /map_relation  /= in Hord.
+    specialize (Hord i).
+    rewrite /option_relation in Hord |- *.
+    destruct (x!!i) eqn:Hxi; rewrite Hxi in Hord |-*; try done.
+    destruct (y!!i) eqn:Hy; rewrite Hy in Hord |-*; try done.
+    eapply ora_orderN_le; eauto.
   - intros ???? Hxy Hyz i.
     eapply (@ora_orderN_trans _ (optionR A)); [apply Hxy | apply Hyz].
   - intros ???? Hord i.

--- a/theories/algebra/gmap.v
+++ b/theories/algebra/gmap.v
@@ -15,8 +15,7 @@ Proof.
 Qed.
 
 Section ora.
-
-Context `{Countable K} {A : ora}.
+Context {SI : sidx} `{Countable K} {A : ora}.
 Implicit Types m : gmap K A.
 
 Instance gmap_orderN : OraOrderN (gmap K A) := λ n, map_relation (λ _, ora_orderN A n) (λ _ _, False) (λ _, Increasing).
@@ -36,9 +35,9 @@ Proof.
   apply ora_total_mixin; try apply _; try done.
   - intros ???; simpl.
     rewrite lookup_op lookup_core.
-    eapply (@ora_core_increasing (optionR A)), _.
+    eapply (@ora_core_increasing _ (optionR A)), _.
   - intros ??? Hincr Hord z i.
-    rewrite lookup_op; eapply (@ora_increasing_closed (optionR A)), Hord.
+    rewrite lookup_op; eapply (@ora_increasing_closed _ (optionR A)), Hord.
     by apply lookup_increasing.
   - intros ??? Hord i.
     rewrite !lookup_core.
@@ -47,9 +46,9 @@ Proof.
   - intros ???? Hx Hord.
     hnf in Hord.
     destruct (list_choice (λ '(i, a) yy,
-      yy.1 ⋅ yy.2 ≼ₒ{S n} Some a ∧ yy.1 ≡{n}≡ y1 !! i ∧ yy.2 ≡{n}≡ y2 !! i) (map_to_list x)) as [gg Hgg].
+      yy.1 ⋅ yy.2 ≼ₒ{Sᵢ n} Some a ∧ yy.1 ≡{n}≡ y1 !! i ∧ yy.2 ≡{n}≡ y2 !! i) (map_to_list x)) as [gg Hgg].
     { rewrite (Forall_iff _ _ (uncurry (λ i a, (∃ yy,
-        yy.1 ⋅ yy.2 ≼ₒ{S n} Some a ∧ yy.1 ≡{n}≡ y1 !! i ∧ yy.2 ≡{n}≡ y2 !! i)))); last by intros (?, ?).
+        yy.1 ⋅ yy.2 ≼ₒ{Sᵢ n} Some a ∧ yy.1 ≡{n}≡ y1 !! i ∧ yy.2 ≡{n}≡ y2 !! i)))); last by intros (?, ?).
       rewrite -map_Forall_to_list; intros ? a Ha.
       destruct (ora_op_extend n (Some a) (y1 !! i) (y2 !! i)) as (z1&z2&Hz).
       * by specialize (Hx i); rewrite Ha in Hx.
@@ -58,7 +57,7 @@ Proof.
     exists (map_imap (λ i _, (list_find(A := (_ * ora_car A) * _) (λ e, e.1.1 = i) (zip (map_to_list x) gg)) ≫= (fun e => e.2.2.1)) x),
            (map_imap (λ i _, (list_find(A := (_ * ora_car A) * _) (λ e, e.1.1 = i) (zip (map_to_list x) gg)) ≫= (fun e => e.2.2.2)) x).
     assert (forall i a, x !! i = Some a -> exists ni yy1 yy2, list_find (λ e, e.1.1 = i) (zip (map_to_list x) gg) =
-      Some (ni, ((i, a), (yy1, yy2))) /\ yy1 ⋅ yy2 ≼ₒ{S n} Some a ∧ yy1 ≡{n}≡ y1 !! i ∧ yy2 ≡{n}≡ y2 !! i) as Hgg'.
+      Some (ni, ((i, a), (yy1, yy2))) /\ yy1 ⋅ yy2 ≼ₒ{Sᵢ n} Some a ∧ yy1 ≡{n}≡ y1 !! i ∧ yy2 ≡{n}≡ y2 !! i) as Hgg'.
     { intros ?? Hxi.
       pose proof (proj2 (elem_of_map_to_list _ _ _) Hxi) as Helem.
       apply elem_of_list_lookup_1 in Helem as (ni & Hmap).
@@ -87,8 +86,8 @@ Proof.
         rewrite op_None in Hop; destruct Hop as [_ Hy2].
         by rewrite Hy2.
   - intros ??? Hx Hord.
-    destruct (list_choice (λ '(i, a) yy, yy ≼ₒ{S n} Some a ∧ yy ≡{n}≡ y !! i) (map_to_list x)) as [gg Hgg].
-    { rewrite (Forall_iff _ _ (uncurry (λ i a, (∃ yy, yy ≼ₒ{S n} Some a ∧ yy ≡{n}≡ y !! i)))); last by intros (?, ?).
+    destruct (list_choice (λ '(i, a) yy, yy ≼ₒ{Sᵢ n} Some a ∧ yy ≡{n}≡ y !! i) (map_to_list x)) as [gg Hgg].
+    { rewrite (Forall_iff _ _ (uncurry (λ i a, (∃ yy, yy ≼ₒ{Sᵢ n} Some a ∧ yy ≡{n}≡ y !! i)))); last by intros (?, ?).
       rewrite -map_Forall_to_list; intros ? a Ha.
       destruct (ora_extend n (Some a) (y !! i)) as (z&Hz).
       * by specialize (Hx i); rewrite Ha in Hx.
@@ -96,7 +95,7 @@ Proof.
       * exists z; eauto. }
     exists (map_imap (λ i _, (list_find(A := (_ * ora_car A) * _) (λ e, e.1.1 = i) (zip (map_to_list x) gg)) ≫= (fun e => e.2.2)) x).
     assert (forall i a, x !! i = Some a -> exists ni yy, list_find (λ e, e.1.1 = i) (zip (map_to_list x) gg) =
-      Some (ni, ((i, a), yy)) /\ yy ≼ₒ{S n} Some a ∧ yy ≡{n}≡ y !! i) as Hgg'.
+      Some (ni, ((i, a), yy)) /\ yy ≼ₒ{Sᵢ n} Some a ∧ yy ≡{n}≡ y !! i) as Hgg'.
     { intros ?? Hxi.
       pose proof (proj2 (elem_of_map_to_list _ _ _) Hxi) as Helem.
       apply elem_of_list_lookup_1 in Helem as (ni & Hmap).
@@ -118,29 +117,31 @@ Proof.
       * specialize (Hord i); rewrite Hxi in Hord.
         destruct (y !! i) eqn: Hy; rewrite Hy in Hord |- *; done.
   - intros ?????.
-    apply (@ora_dist_orderN (optionR A)); auto.
+    apply (@ora_dist_orderN _ (optionR A)); auto.
   - intros ??? Hord i.
-    apply (@ora_orderN_S (optionR A)), Hord.
+    apply (@ora_orderN_S _ (optionR A)), Hord.
   - intros ???? Hxy Hyz i.
-    eapply (@ora_orderN_trans (optionR A)); [apply Hxy | apply Hyz].
+    eapply (@ora_orderN_trans _ (optionR A)); [apply Hxy | apply Hyz].
   - intros ???? Hord i.
     rewrite !lookup_op.
-    eapply (@ora_orderN_op (optionR A)), Hord.
+    eapply (@ora_orderN_op _ (optionR A)), Hord.
   - intros ???? Hord i.
-    eapply (@ora_validN_orderN (optionR A)), Hord; auto.
-  - split; intros; intros i; eapply (@ora_order_orderN (optionR A)).
+    eapply (@ora_validN_orderN _ (optionR A)), Hord; auto.
+  - split; intros; intros i; eapply (@ora_order_orderN _ (optionR A)).
     + apply H0.
     + intros; apply H0.
   - intros ??? Hcx.
     eexists; split; [constructor; reflexivity|].
     inversion Hcx as [?? Heq|]; subst.
     intros i.
-    rewrite -Heq !lookup_omap lookup_op.
+    Fail rewrite -Heq. (* FIXME *)
+    (* rewrite -Heq !lookup_omap lookup_op.
     edestruct (ora_pcore_order_op (x !! i)) as (? & Hcore & ?).
     { constructor; reflexivity. }
     inversion Hcore as [?? Hxy|]; subst.
     by rewrite Hxy.
-Qed.
+Qed. *)
+Admitted.
 Canonical Structure gmapR : ora := Ora (gmap K A) gmap_ora_mixin.
 
 Global Instance gmap_ora_discrete : OraDiscrete A → OraDiscrete gmapR.
@@ -158,13 +159,18 @@ Lemma gmap_uora_mixin : UoraMixin (gmap K A).
 Proof. split. intros ? Hu ?. specialize (Hu i); rewrite lookup_empty in Hu. by inv Hu. Qed.
 
 Canonical Structure gmapUR : uora := Uora (gmap K A) (gmap_ucmra_mixin(H := H)(A := A)) gmap_uora_mixin.
+Global Instance gmap_op_empty_l_L : LeftId (=@{gmap K A}) ∅ op.
+Proof. apply _. Qed.
+Global Instance gmap_op_empty_r : RightId (=@{gmap K A}) ∅ op.
+Proof. apply _. Qed.
 
 End ora.
 
-Global Arguments gmapR _ {_ _} _.
-Global Arguments gmapUR _ {_ _} _.
+Global Arguments gmapR {_} _ {_ _} _.
+Global Arguments gmapUR {_} _ {_ _} _.
 
 Section properties.
+Context {SI : sidx}.
 Context `{Countable K} {A : ora}.
 Implicit Types m : gmap K A.
 Implicit Types i : K.
@@ -181,7 +187,7 @@ Proof. intros. by apply core_id_total, (singleton_core'(A := A)). Qed.
 
 End properties.
 
-Global Instance gmap_fmap_ora_morphism `{Countable K} {A B : ora} (f : A → B)
+Global Instance gmap_fmap_ora_morphism {SI : sidx} `{Countable K} {A B : ora} (f : A → B)
   `{!OraMorphism f} : OraMorphism (fmap f : gmap K A → gmap K B).
 Proof.
   split; try apply _.
@@ -194,34 +200,35 @@ Proof.
     by apply lookup_increasing.
 Qed.
 
-Program Definition gmapURF K `{Countable K} (F : OrarFunctor) : uorarFunctor := {|
+Program Definition gmapURF {SI : sidx} K `{Countable K} (F : OrarFunctor) : uorarFunctor := {|
   uorarFunctor_car A _ B _ := gmapUR K (orarFunctor_car F A B);
   uorarFunctor_map A1 _ A2 _ B1 _ B2 _ fg := gmapO_map (orarFunctor_map F fg)
 |}.
 Next Obligation.
-  by intros K ?? F A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply gmapO_map_ne, orarFunctor_map_ne.
+  by intros ?? K ?? F A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply gmapO_map_ne, orarFunctor_map_ne.
 Qed.
 Next Obligation.
-  intros K ?? F A ? B ? x. rewrite /= -{2}(map_fmap_id x).
+  intros ? K ?? F A ? B ? m.
+  rewrite /= -{2}(map_fmap_id m).
   apply map_fmap_equiv_ext=>y ??; apply orarFunctor_map_id.
 Qed.
 Next Obligation.
-  intros K ?? F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x. rewrite /= -map_fmap_compose.
+  intros ?? K ?? F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x. rewrite /= -map_fmap_compose.
   apply map_fmap_equiv_ext=>y ??; apply orarFunctor_map_compose.
 Qed.
 
-Global Instance gmapURF_contractive K `{Countable K} F :
+Global Instance gmapURF_contractive {SI : sidx} K `{Countable K} F :
   OrarFunctorContractive F → uorarFunctorContractive (gmapURF K F).
 Proof.
   by intros ? A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply gmapO_map_ne, orarFunctor_map_contractive.
 Qed.
 
-Program Definition gmapRF K `{Countable K} (F : OrarFunctor) : OrarFunctor := {|
+Program Definition gmapRF {SI : sidx} K `{Countable K} (F : OrarFunctor) : OrarFunctor := {|
   orarFunctor_car A _ B _ := gmapR K (orarFunctor_car F A B);
   orarFunctor_map A1 _ A2 _ B1 _ B2 _ fg := gmapO_map (orarFunctor_map F fg)
 |}.
-Solve Obligations with apply gmapURF.
+Solve Obligations with apply @gmapURF.
 
-Global Instance gmapRF_contractive K `{Countable K} F :
+Global Instance gmapRF_contractive {SI : sidx} K `{Countable K} F :
   OrarFunctorContractive F → OrarFunctorContractive (gmapRF K F).
 Proof. apply gmapURF_contractive. Qed.

--- a/theories/algebra/gmap_view.v
+++ b/theories/algebra/gmap_view.v
@@ -22,13 +22,13 @@ NOTE: The API surface for [gmap_view] is experimental and subject to change.  We
 plan to add notations for authoritative elements and fragments, and hope to
 support arbitrary maps as fragments. *)
 
-Local Definition gmap_view_fragUR (K : Type) `{Countable K} (V : ofe) : uora :=
+Local Definition gmap_view_fragUR {SI : sidx} (K : Type) `{Countable K} (V : ofe) : uora :=
   gmapUR K (prodR dfracR (agreeR V)).
 
 (** View relation. *)
 Section rel.
-  Context (K : Type) `{Countable K} (V : ofe).
-  Implicit Types (m : gmap K V) (k : K) (v : V) (n : nat).
+  Context {SI : sidx} (K : Type) `{Countable K} (V : ofe).
+  Implicit Types (m : gmap K V) (k : K) (v : V) (n : SI).
   Implicit Types (f : gmap K (dfrac * agree V)).
 
   Local Definition gmap_view_rel_raw n m f : Prop :=
@@ -38,7 +38,7 @@ Section rel.
     gmap_view_rel_raw n1 m1 f1 →
     m1 ≡{n2}≡ m2 →
     f2 ≼{n2} f1 →
-    n2 ≤ n1 →
+    (n2 ≤ n1)%sidx →
     gmap_view_rel_raw n2 m2 f2.
   Proof.
     intros Hrel Hm Hf Hn k [q va] Hk.
@@ -143,19 +143,19 @@ Local Existing Instance gmap_view_rel_discrete.
 (** [gmap_view] is a notation to give canonical structure search the chance
 to infer the right instances (see [auth]). *)
 Notation gmap_view K V := (view (@gmap_view_rel_raw K _ _ V)).
-Definition gmap_viewO (K : Type) `{Countable K} (V : ofe) : ofe :=
+Definition gmap_viewO {SI : sidx} (K : Type) `{Countable K} (V : ofe) : ofe :=
   viewO (gmap_view_rel K V).
-Definition gmap_viewC (K : Type) `{Countable K} (V : ofe) : cmra :=
+Definition gmap_viewC {SI : sidx} (K : Type) `{Countable K} (V : ofe) : cmra :=
   iris.algebra.view.viewR (gmap_view_rel K V).
-Definition gmap_viewUC (K : Type) `{Countable K} (V : ofe) : ucmra :=
+Definition gmap_viewUC {SI : sidx} (K : Type) `{Countable K} (V : ofe) : ucmra :=
   iris.algebra.view.viewUR (gmap_view_rel K V).
-Canonical Structure gmap_viewR (K : Type) `{Countable K} (V : ofe) : ora :=
+Canonical Structure gmap_viewR {SI : sidx} (K : Type) `{Countable K} (V : ofe) : ora :=
   view.viewR (gmap_view_rel K V) (gmap_view_rel_order K V).
-Canonical Structure gmap_viewUR (K : Type) `{Countable K} (V : ofe) : uora :=
+Canonical Structure gmap_viewUR {SI : sidx} (K : Type) `{Countable K} (V : ofe) : uora :=
   viewUR (gmap_view_rel K V).
 
 Section definitions.
-  Context {K : Type} `{Countable K} {V : ofe}.
+  Context {SI : sidx} {K : Type} `{Countable K} {V : ofe}.
 
   Definition gmap_view_auth (dq : dfrac) (m : gmap K V) : gmap_viewC K V :=
     ●V{dq} m.
@@ -164,7 +164,7 @@ Section definitions.
 End definitions.
 
 Section lemmas.
-  Context {K : Type} `{Countable K} {V : ofe}.
+  Context {SI : sidx} {K : Type} `{Countable K} {V : ofe}.
   Implicit Types (m : gmap K V) (k : K) (q : Qp) (dq : dfrac) (v : V).
 
   Global Instance : Params (@gmap_view_auth) 5 := {}.
@@ -254,7 +254,8 @@ Section lemmas.
   Lemma gmap_view_frag_valid k dq v : ✓ gmap_view_frag k dq v ↔ ✓ dq.
   Proof.
     rewrite cmra_valid_validN. setoid_rewrite gmap_view_frag_validN.
-    naive_solver eauto using O.
+    pose 0ᵢ.
+    naive_solver.
   Qed.
 
   Lemma gmap_view_frag_op k dq1 dq2 v :
@@ -305,7 +306,7 @@ Section lemmas.
     rewrite view_both_dfrac_valid. setoid_rewrite gmap_view_rel_lookup.
     split=>[[Hq Hm]|[Hq Hm]].
     - split; first done. split.
-      + apply (Hm 0%nat).
+      + apply (Hm 0ᵢ).
       + apply equiv_dist=>n. apply Hm.
     - split; first done. intros n. split.
       + apply Hm.
@@ -466,7 +467,7 @@ Section lemmas.
 End lemmas.
 
 (** Functor *)
-Program Definition gmap_viewURF (K : Type) `{Countable K} (F : oFunctor) : uorarFunctor := {|
+Program Definition gmap_viewURF {SI : sidx} (K : Type) `{Countable K} (F : oFunctor) : uorarFunctor := {|
   uorarFunctor_car A _ B _ := gmap_viewUR K (oFunctor_car F A B);
   uorarFunctor_map A1 _ A2 _ B1 _ B2 _ fg :=
     viewO_map (rel:=gmap_view_rel K (oFunctor_car F A1 B1))
@@ -475,14 +476,14 @@ Program Definition gmap_viewURF (K : Type) `{Countable K} (F : oFunctor) : uorar
               (gmapO_map (K:=K) (prodO_map cid (agreeO_map (oFunctor_map F fg))))
 |}.
 Next Obligation.
-  intros K ?? F A1 ? A2 ? B1 ? B2 ? n f g Hfg.
+  intros ? K ?? F A1 ? A2 ? B1 ? B2 ? n f g Hfg.
   apply viewO_map_ne.
   - apply gmapO_map_ne, oFunctor_map_ne. done.
   - apply gmapO_map_ne. apply prodO_map_ne; first done.
     apply agreeO_map_ne, oFunctor_map_ne. done.
 Qed.
 Next Obligation.
-  intros K ?? F A ? B ? x; simpl in *. rewrite -{2}(view_map_id x).
+  intros ? K ?? F A ? B ? x; simpl in *. rewrite -{2}(view_map_id x).
   apply (view_map_ext _ _ _ _)=> y.
   - rewrite /= -{2}(map_fmap_id y).
     apply map_fmap_equiv_ext=>k ??.
@@ -495,7 +496,7 @@ Next Obligation.
     apply oFunctor_map_id.
 Qed.
 Next Obligation.
-  intros K ?? F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x; simpl in *.
+  intros ? K ?? F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x; simpl in *.
   rewrite -view_map_compose.
   apply (view_map_ext _ _ _ _)=> y.
   - rewrite /= -map_fmap_compose.
@@ -509,7 +510,7 @@ Next Obligation.
     apply oFunctor_map_compose.
 Qed.
 Next Obligation.
-  intros K ?? F A1 ? A2 ? B1 ? B2 ? fg; simpl.
+  intros ? K ?? F A1 ? A2 ? B1 ? B2 ? fg; simpl.
   (* [apply] does not work, probably the usual unification probem (Coq #6294) *)
   apply: view_map_ora_morphism; [apply _..|]=> n m f.
   intros Hrel k [df va] Hf. move: Hf.
@@ -522,7 +523,7 @@ Next Obligation.
   rewrite Hagree. rewrite agree_map_to_agree. done.
 Qed.
 
-Global Instance gmap_viewURF_contractive (K : Type) `{Countable K} F :
+Global Instance gmap_viewURF_contractive {SI : sidx} (K : Type) `{Countable K} F :
   oFunctorContractive F → uorarFunctorContractive (gmap_viewURF K F).
 Proof.
   intros ? A1 ? A2 ? B1 ? B2 ? n f g Hfg.
@@ -532,7 +533,7 @@ Proof.
     apply agreeO_map_ne, oFunctor_map_contractive. done.
 Qed.
 
-Program Definition gmap_viewRF (K : Type) `{Countable K} (F : oFunctor) : OrarFunctor := {|
+Program Definition gmap_viewRF {SI : sidx} (K : Type) `{Countable K} (F : oFunctor) : OrarFunctor := {|
   orarFunctor_car A _ B _ := gmap_viewR K (oFunctor_car F A B);
   orarFunctor_map A1 _ A2 _ B1 _ B2 _ fg :=
     viewO_map (rel:=gmap_view_rel K (oFunctor_car F A1 B1))
@@ -540,9 +541,9 @@ Program Definition gmap_viewRF (K : Type) `{Countable K} (F : oFunctor) : OrarFu
               (gmapO_map (K:=K) (oFunctor_map F fg))
               (gmapO_map (K:=K) (prodO_map cid (agreeO_map (oFunctor_map F fg))))
 |}.
-Solve Obligations with apply gmap_viewURF.
+Solve Obligations with apply @gmap_viewURF.
 
-Global Instance gmap_viewRF_contractive (K : Type) `{Countable K} F :
+Global Instance gmap_viewRF_contractive {SI : sidx} (K : Type) `{Countable K} F :
   oFunctorContractive F → OrarFunctorContractive (gmap_viewRF K F).
 Proof. apply gmap_viewURF_contractive. Qed.
 

--- a/theories/algebra/ora.v
+++ b/theories/algebra/ora.v
@@ -48,6 +48,7 @@ Section mixin.
       ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{Sᵢ n} x ∧ z ≡{n}≡ y;
     (* OraOrder *)
     mixin_ora_dist_orderN n x y : x ≡{n}≡ y → x ≼ₒ{n} y;
+    (* FIXME Is this strong enough? *)
     mixin_ora_orderN_S n x y : x ≼ₒ{Sᵢ n} y → x ≼ₒ{n} y;
     mixin_ora_orderN_trans n : Transitive (OraorderN n);
     mixin_ora_orderN_op n x x' y : x ≼ₒ{n} x' → x ⋅ y ≼ₒ{n} x' ⋅ y;
@@ -412,8 +413,19 @@ Proof. intros Hyv [z ?]; setoid_subst; eauto using ora_valid_op_l. Qed.
 Lemma ora_validN_order n x y : ✓{n} y → x ≼ y → ✓{n} x.
 Proof. intros Hyv [z ?]; setoid_subst; eauto using ora_validN_op_l. Qed.*)
 Local Set Primitive Projections.
-Lemma ora_orderN_le n n' x y : x ≼ₒ{n} y → (n' ≤ n)%sidx → x ≼ₒ{n'} y.
-Proof. intros ? H. induction H.  induction 2; auto using ora_orderN_S. Qed.
+Lemma ora_orderN_le n n' x y : x ≼ₒ{n} y → n' ≤ n → x ≼ₒ{n'} y.
+Proof.
+  induction (SIdx.lt_wf n) as [n _ IH]; intros.
+  rewrite SIdx.le_lteq in H0.  destruct H0 as [?|Hlt].
+  2: { subst. done. }
+  (* case on whether n has a predecessor *)
+  destruct (SIdx.weak_case n).
+  - destruct s as [pred_n ->].
+    eapply (IH pred_n). 
+    { apply SIdx.lt_succ_diag_r. }
+    { by apply ora_orderN_S. }
+    rewrite -SIdx.lt_succ_r //.
+  - Admitted.
 
 (* Lemma ora_pcore_order_op' x cx y : *)
 (*   pcore x ≡ Some cx → ∃ cxy, pcore (x ⋅ y) = Some cxy ∧ cx ≼ₒ cxy. *)
@@ -491,7 +503,7 @@ Proof. by intros ?; apply ora_order_orderN. Qed.*)
 (** ** Total core *)
 Section total_core.
   Local Set Default Proof Using "Type*".
-  Context `{OraTotal A}.
+  Context `{!OraTotal A}.
 
   Lemma ora_core_l x : core x ⋅ x ≡ x.
   Proof.
@@ -551,7 +563,7 @@ Section total_core.
 
   Lemma ora_included_core x : core x ≼ x.
   Proof. by exists x; rewrite ora_core_l. Qed.
-  Global Instance ora_orderN_preorder n : PreOrder (@OraorderN A _ n).
+  Global Instance ora_orderN_preorder n : PreOrder (@OraorderN SI A _ n).
   Proof.
     split; [|apply _]; auto.
   Qed.
@@ -587,24 +599,24 @@ End total_core.
 (* Qed. *)
 
 (** ** Discrete *)
-Instance ora_cmra_discrete `{OraDiscrete A} : CmraDiscrete A.
+Instance ora_cmra_discrete `{!OraDiscrete A} : CmraDiscrete A.
 Proof.
-  destruct H; split; auto.
+  destruct OraDiscrete0; split; auto.
 Qed.
 
-Lemma ora_discrete_valid_iff `{OraDiscrete A} n x : ✓ x ↔ ✓{n} x.
+Lemma ora_discrete_valid_iff `{!OraDiscrete A} n x : ✓ x ↔ ✓{n} x.
 Proof.
   split; first by rewrite cmra_valid_validN.
-  eauto using ora_discrete_valid, cmra_validN_le with lia.
+  eauto using ora_discrete_valid, cmra_validN_le, SIdx.le_0_l.
 Qed.
-Lemma ora_discrete_valid_iff_0 `{OraDiscrete A} n x : ✓{0} x ↔ ✓{n} x.
+Lemma ora_discrete_valid_iff_0 `{!OraDiscrete A} n x : ✓{0ᵢ} x ↔ ✓{n} x.
 Proof. apply cmra_discrete_valid_iff_0. Qed.
-Lemma ora_discrete_included_iff `{OraDiscrete A} n x y : x ≼ₒ y ↔ x ≼ₒ{n} y.
+Lemma ora_discrete_included_iff `{!OraDiscrete A} n x y : x ≼ₒ y ↔ x ≼ₒ{n} y.
 Proof.
   split => ?; first by apply ora_order_orderN.
-  apply ora_discrete_order; eapply ora_orderN_le; first eauto; lia.
+  apply ora_discrete_order; eapply ora_orderN_le, SIdx.le_0_l; eauto.
 Qed.
-Lemma cmra_discrete_included_iff_0 `{OraDiscrete A} n x y : x ≼ₒ{0} y ↔ x ≼ₒ{n} y.
+Lemma cmra_discrete_included_iff_0 `{!OraDiscrete A} n x y : x ≼ₒ{0ᵢ} y ↔ x ≼ₒ{n} y.
 Proof. by rewrite -!ora_discrete_included_iff. Qed.
 
 (* (** Cancelable elements  *) *)
@@ -660,11 +672,11 @@ End ora.
 
 (** * Properties about CMRAs with a unit element **)
 Section uora.
-  Context {A : uora}.
+  Context {SI: sidx} {A : uora}.
   Implicit Types x y z : A.
 
   Lemma uora_unit_validN n : ✓{n} (ε:A).
-  Proof. apply (@cmra_valid_validN (ora_cmraR _)), ucmra_unit_valid. Qed.
+  Proof. apply (@cmra_valid_validN _ (ora_cmraR _)), ucmra_unit_valid. Qed.
   Global Instance uora_unit_right_id : RightId (≡) ε (@op A _).
   Proof. apply ucmra_unit_right_id. Qed.
   Global Instance uora_unit_core_id : OraCoreId (ε:A).
@@ -783,22 +795,22 @@ End uora_leibniz.*)
 
 (** * Constructing an ORA with total core *)
 Section ora_total.
-  Context A `{!Dist A, !Equiv A, !PCore A, !Op A, !Valid A, !ValidN A, OraOrder A, OraOrderN A}.
+  Context {SI: sidx} A `{!Dist A, !Equiv A, !PCore A, !Op A, !Valid A, !ValidN A, !OraOrder A, !OraOrderN A}.
   Context (total : ∀ x : A, is_Some (pcore x)).
   Context (core_increasing : ∀ x, Increasing (core x)).
   Context (increasing_closed : ∀ n x y, Increasing x → x ≼ₒ{n} y → Increasing y).
   Context (core_monoN : ∀ n x y, x ≼ₒ{n} y → core x ≼ₒ{n} core y).
-  Context (op_extend : ∀ (n : nat) (x y1 y2 : A),
+  Context (op_extend : ∀ n (x y1 y2 : A),
               ✓{n} x → y1 ⋅ y2 ≼ₒ{n} x →
               ∃ z1 z2, z1 ⋅ z2 ≼ₒ{Sᵢ n} x ∧ z1 ≡{n}≡ y1 ∧ z2 ≡{n}≡ y2).
-  Context (extend_order : ∀ (n : nat) (x y : A),
+  Context (extend_order : ∀ n (x y : A),
               ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{Sᵢ n} x ∧ z ≡{n}≡ y).
-  Context (dist_orderN : ∀ (n : nat) (x y : A), x ≡{n}≡ y → x ≼ₒ{n} y).
-  Context (orderN_S : ∀ (n : nat) (x y : A), x ≼ₒ{Sᵢ n} y → x ≼ₒ{n} y).
-  Context (OrderN_trans : ∀ n : nat, Transitive (OraorderN n)).
-  Context (orderN_op : ∀ (n : nat) (x x' y : A), x ≼ₒ{n} x' → x ⋅ y ≼ₒ{n} x' ⋅ y).
-  Context (validN_orderN : ∀ (n : nat) (x y : A), ✓{n} x → y ≼ₒ{n} x → ✓{n} y).
-  Context (order_orderN : ∀ x y : A, x ≼ₒ y ↔ (∀ n : nat, x ≼ₒ{n} y)).
+  Context (dist_orderN : ∀ n (x y : A), x ≡{n}≡ y → x ≼ₒ{n} y).
+  Context (orderN_S : ∀ n (x y : A), x ≼ₒ{Sᵢ n} y → x ≼ₒ{n} y).
+  Context (OrderN_trans : ∀ n, Transitive (OraorderN n)).
+  Context (orderN_op : ∀ n (x x' y : A), x ≼ₒ{n} x' → x ⋅ y ≼ₒ{n} x' ⋅ y).
+  Context (validN_orderN : ∀ n (x y : A), ✓{n} x → y ≼ₒ{n} x → ✓{n} y).
+  Context (order_orderN : ∀ x y : A, x ≼ₒ y ↔ (∀ n, x ≼ₒ{n} y)).
   Context (pcore_order_op : ∀ x cx y : A,
               pcore x ≡ Some cx →
               ∃ cxy : A, pcore (x ⋅ y) ≡ Some cxy ∧ cx ≼ₒ cxy).
@@ -813,11 +825,11 @@ Section ora_total.
 End ora_total.
 
 (** * Properties about morphisms *)
-#[export] Instance ora_morphism_id {A : ora} : OraMorphism (@id A).
+#[export] Instance ora_morphism_id {SI: sidx} {A : ora} : OraMorphism (@id A).
 Proof. split=>//=. apply cmra_morphism_id. Qed.
-#[export] Instance ora_morphism_proper {A B : ora} (f : A → B) `{!OraMorphism f} :
+#[export] Instance ora_morphism_proper {SI: sidx} {A B : ora} (f : A → B) `{!OraMorphism f} :
   Proper ((≡) ==> (≡)) f := ne_proper _.
-#[export] Instance ora_morphism_compose {A B C : ora} (f : A → B) (g : B → C) :
+#[export] Instance ora_morphism_compose {SI: sidx} {A B C : ora} (f : A → B) (g : B → C) :
   OraMorphism f → OraMorphism g → OraMorphism (g ∘ f).
 Proof.
   split.
@@ -830,7 +842,7 @@ Qed.
 
 Section ora_morphism.
   Local Set Default Proof Using "Type*".
-  Context {A B : ora} (f : A → B) `{!OraMorphism f}.
+  Context {SI: sidx} {A B : ora} (f : A → B) `{!OraMorphism f}.
 
   Lemma ora_morphism_validN n (x : A) : ✓{n} x → ✓{n} f x.
   Proof. apply cmra_morphism_validN, _. Qed.
@@ -853,7 +865,7 @@ Section ora_morphism.
 End ora_morphism.
 
 (** Functors *)
-Record OrarFunctor := OraRFunctor {
+Record OrarFunctor {SI: sidx} := OraRFunctor {
   orarFunctor_car : ∀ A `{!Cofe A} B `{!Cofe B}, ora;
   orarFunctor_map `{!Cofe A1, !Cofe A2, !Cofe B1, !Cofe B2} :
     ((A2 -n> A1) * (B1 -n> B2)) → orarFunctor_car A1 B1 -n> orarFunctor_car A2 B2;
@@ -869,28 +881,29 @@ Record OrarFunctor := OraRFunctor {
     OraMorphism (orarFunctor_map fg)
 }.
 #[export] Existing Instances orarFunctor_map_ne orarFunctor_mor.
-#[export] Instance: Params (@orarFunctor_map) 5 := {}.
+#[export] Instance: Params (@orarFunctor_map) 10 := {}.
 
 Declare Scope orarFunctor_scope.
 Delimit Scope orarFunctor_scope with ORF.
 Bind Scope orarFunctor_scope with rFunctor.
 
-Class OrarFunctorContractive (F : OrarFunctor) :=
-  orarFunctor_map_contractive `{!Cofe A1, !Cofe A2, !Cofe B1, !Cofe B2} ::
-    Contractive (@orarFunctor_map F A1 _ A2 _ B1 _ B2 _).
+Class OrarFunctorContractive {SI: sidx} (F : OrarFunctor) :=
+  #[global] orarFunctor_map_contractive `{!Cofe A1, !Cofe A2, !Cofe B1, !Cofe B2} ::
+    Contractive (@orarFunctor_map SI F A1 _ A2 _ B1 _ B2 _).
+Global Hint Mode rFunctorContractive - ! : typeclass_instances.
 
-Definition OrarFunctor_apply (F: OrarFunctor) (A: ofe) `{!Cofe A} : ora := orarFunctor_car F A A.
+Definition OrarFunctor_apply {SI: sidx} (F: OrarFunctor) (A: ofe) `{!Cofe A} : ora := orarFunctor_car F A A.
 Coercion OrarFunctor_apply : OrarFunctor >-> Funclass.
 
-Program Definition OraconstRF (B : ora) : OrarFunctor :=
+Program Definition OraconstRF {SI: sidx} (B : ora) : OrarFunctor :=
   {| orarFunctor_car A1 _ A2 _ := B; orarFunctor_map A1 _ A2 _ B1 _ B2 _ f := cid |}.
 Solve Obligations with done.
 Coercion OraconstRF : ora >-> OrarFunctor.
 
-#[export] Instance OraconstRF_contractive B : OrarFunctorContractive (OraconstRF B).
+#[export] Instance OraconstRF_contractive {SI: sidx} B : OrarFunctorContractive (OraconstRF B).
 Proof. rewrite /OrarFunctorContractive; apply _. Qed.
 
-Record uorarFunctor := UOraRFunctor {
+Record uorarFunctor {SI: sidx} := UOraRFunctor {
   uorarFunctor_car : ∀ A `{!Cofe A} B `{!Cofe B}, uora;
   uorarFunctor_map `{!Cofe A1, !Cofe A2, !Cofe B1, !Cofe B2} :
     ((A2 -n> A1) * (B1 -n> B2)) → uorarFunctor_car A1 B1 -n> uorarFunctor_car A2 B2;
@@ -906,37 +919,38 @@ Record uorarFunctor := UOraRFunctor {
     OraMorphism (uorarFunctor_map fg)
 }.
 #[export] Existing Instances uorarFunctor_map_ne uorarFunctor_mor.
-#[export] Instance: Params (@uorarFunctor_map) 5 := {}.
+#[export] Instance: Params (@uorarFunctor_map) 10 := {}.
 
 Declare Scope uorarFunctor_scope.
 Delimit Scope uorarFunctor_scope with UORF.
 Bind Scope uorarFunctor_scope with uorarFunctor.
 
-Class uorarFunctorContractive (F : uorarFunctor) :=
-  uorarFunctor_map_contractive `{!Cofe A1, !Cofe A2, !Cofe B1, !Cofe B2} ::
-    Contractive (@uorarFunctor_map F A1 _ A2 _ B1 _ B2 _).
+Class uorarFunctorContractive {SI: sidx} (F : uorarFunctor) :=
+  #[global] uorarFunctor_map_contractive `{!Cofe A1, !Cofe A2, !Cofe B1, !Cofe B2} ::
+    Contractive (@uorarFunctor_map _ F A1 _ A2 _ B1 _ B2 _).
+Global Hint Mode urFunctorContractive - ! : typeclass_instances.
 
-Definition uorarFunctor_apply (F: uorarFunctor) (A: ofe) `{!Cofe A} : uora :=
+Definition uorarFunctor_apply {SI: sidx} (F: uorarFunctor) (A: ofe) `{!Cofe A} : uora :=
   uorarFunctor_car F A A.
 
-Program Definition OraconstURF (B : uora) : uorarFunctor :=
+Program Definition OraconstURF {SI: sidx} (B : uora) : uorarFunctor :=
   {| uorarFunctor_car A1 _ A2 _ := B; uorarFunctor_map A1 _ A2 _ B1 _ B2 _ f := cid |}.
 Solve Obligations with done.
 Coercion OraconstURF : uora >-> uorarFunctor.
 
-#[export] Instance OraconstURF_contractive B : uorarFunctorContractive (OraconstURF B).
+#[export] Instance OraconstURF_contractive {SI: sidx} B : uorarFunctorContractive (OraconstURF B).
 Proof. rewrite /uorarFunctorContractive; apply _. Qed.
 
 (** * Transporting a CMRA equality *)
-Definition ora_transport {A B : ora} (H : A = B) (x : A) : B :=
+Definition ora_transport {SI: sidx} {A B : ora} (H : A = B) (x : A) : B :=
   eq_rect A id x _ H.
 
-Lemma ora_transport_trans {A B C : ora} (H1 : A = B) (H2 : B = C) x :
+Lemma ora_transport_trans {SI: sidx} {A B C : ora} (H1 : A = B) (H2 : B = C) x :
   ora_transport H2 (ora_transport H1 x) = ora_transport (eq_trans H1 H2) x.
 Proof. by destruct H2. Qed.
 
 Section ora_transport.
-  Context {A B : ora} (H : A = B).
+  Context {SI: sidx} {A B : ora} (H : A = B).
   Notation T := (ora_transport H).
   Global Instance ora_transport_ne : NonExpansive T.
   Proof. by intros ???; destruct H. Qed.
@@ -982,10 +996,10 @@ End mixin.
 
 Section discrete.
   Local Set Default Proof Using "Type*".
-  Context `{Equiv A, OraOrder A, PCore A, Op A, Valid A} (Heq : @Equivalence A (≡)).
+  Context {SI: sidx} {A: Type} `{Equiv A, OraOrder A, PCore A, Op A, Valid A} (Heq : @Equivalence A (≡)).
   Context (dora_mix : DORAMixin A).
   Existing Instances discrete_dist.
-  Global Instance discrete_orderN : OraOrderN A := λ _ x y, x ≼ₒ y.
+  Global Instance discrete_orderN  : OraOrderN A := λ _ x y, x ≼ₒ y.
 
   Instance discrete_validN : ValidN A := λ n x, ✓ x.
   Definition discrete_ora_mixin : OraMixin A.
@@ -993,7 +1007,8 @@ Section discrete.
     destruct dora_mix; split; eauto; try done.
     - intros n x y Hx Hxy z. etrans; first apply Hx.
       eapply dora_order_op; eauto.
-    - intros x; split; first done. by move=> /(_ 0).
+    - intros x; split; first done.
+      by move => /(_ 0ᵢ).
   Qed.
 
   Context (ra_mix : RAMixin A).
@@ -1034,6 +1049,7 @@ End dora_total.
 
 (** ** CMRA for the unit type *)
 Section unit.
+  Context {SI: sidx}.
   Instance unit_valid : Valid () := λ x, True.
   Instance unit_validN : ValidN () := λ n x, True.
   Instance unit_pcore : PCore () := λ x, Some x.
@@ -1063,13 +1079,14 @@ End unit.
 
 (** ** Natural numbers *)
 Section nat.
+  Context {SI: sidx}.
   Instance nat_valid : Valid nat := λ x, True.
   Instance nat_validN : ValidN nat := λ n x, True.
   Instance nat_pcore : PCore nat := λ x, Some 0.
   Instance nat_op : Op nat := plus.
   Instance nat_order : OraOrder nat := le.
   Definition nat_op_plus x y : x ⋅ y = x + y := eq_refl.
-  Lemma nat_order_le (x y : nat) : x ≼ₒ y ↔ x ≤ y.
+  Lemma nat_order_le (x y : nat) : x ≼ₒ y ↔ (x ≤ y)%nat.
   Proof. trivial. Qed.
   Lemma nat_dora_mixin : DORAMixin nat.
   Proof.
@@ -1108,6 +1125,7 @@ End nat.
 Definition mnat := nat.
 
 Section mnat.
+  Context {SI: sidx}.
   Instance mnat_unit : Unit mnat := 0.
   Instance mnat_valid : Valid mnat := λ x, True.
   Instance mnat_validN : ValidN mnat := λ n x, True.
@@ -1115,7 +1133,7 @@ Section mnat.
   Instance mnat_op : Op mnat := Nat.max.
   Instance mnat_order : OraOrder mnat := le.
   Definition mnat_op_max x y : x ⋅ y = x `max` y := eq_refl.
-  Lemma mnat_order_le (x y : mnat) : x ≼ₒ y ↔ x ≤ y.
+  Lemma mnat_order_le (x y : mnat) : x ≼ₒ y ↔ (x ≤ y)%nat.
   Proof. done. Qed.
 
   Lemma mnat_ra_mixin : RAMixin mnat.
@@ -1156,6 +1174,7 @@ End mnat.
 
 (** ** Positive integers. *)
 Section positive.
+  Context {SI: sidx}.
   Instance pos_valid : Valid positive := λ x, True.
   Instance pos_validN : ValidN positive := λ n x, True.
   Instance pos_pcore : PCore positive := λ x, None.
@@ -1189,7 +1208,7 @@ End positive.
 
 (** Product *)
 Section prod.
-  Context {A B : ora}.
+  Context {SI: sidx} {A B : ora}.
   Local Arguments pcore _ _ !_ /.
   Local Arguments prod_pcore_instance _ _ !_/.
   Local Arguments cmra_car _ /.
@@ -1301,10 +1320,10 @@ Section prod.
   Proof. move=>? [??] [_ ?] [_ /=?]. eauto. Qed.
 End prod.
 
-Arguments prodR : clear implicits.
+Arguments prodR {_} _ _.
 
 Section prod_unit.
-  Context {A B : uora}.
+  Context {SI: sidx} {A B : uora}.
 
   Instance prod_unit `{Unit A, Unit B} : Unit (A * B) := (ε, ε).
   Lemma prod_ucmra_mixin : UcmraMixin (A * B).
@@ -1316,7 +1335,7 @@ Section prod_unit.
   Qed.
   Lemma prod_uora_mixin : UoraMixin (A * B).
   Proof. split. intros ? [? ?]. split; by apply uora_unit_discrete. Qed.
-  Canonical Structure prodUR := Uora' (prod A B) (ofe_mixin_of (A * B)) (@prod_cmra_mixin A B) prod_ora_mixin prod_ucmra_mixin prod_uora_mixin.
+  Canonical Structure prodUR := Uora' (prod A B) (ofe_mixin_of (A * B)) (@prod_cmra_mixin _ A B) prod_ora_mixin prod_ucmra_mixin prod_uora_mixin.
 
   Lemma pair_split (x : A) (y : B) : (x, y) ≡ (x, ε) ⋅ (ε, y).
   Proof. by rewrite pair_op left_id right_id. Qed.
@@ -1326,9 +1345,9 @@ Section prod_unit.
   Proof. unfold_leibniz. apply pair_split. Qed.
 End prod_unit.
 
-Arguments prodUR : clear implicits.
+Arguments prodUR {_} _ _.
 
-#[export] Instance prod_map_cmra_morphism {A A' B B' : ora} (f : A → A') (g : B → B') :
+#[export] Instance prod_map_cmra_morphism {SI: sidx} {A A' B B' : ora} (f : A → A') (g : B → B') :
   OraMorphism f → OraMorphism g → OraMorphism (prod_map f g).
 Proof.
   split; first apply _.
@@ -1340,22 +1359,22 @@ Proof.
       { intros z. destruct (Hx (x.1, z)); simpl in *; auto. }
 Qed.
 
-Program Definition prodRF (F1 F2 : OrarFunctor) : OrarFunctor := {|
+Program Definition prodRF {SI: sidx} (F1 F2 : OrarFunctor) : OrarFunctor := {|
   orarFunctor_car A _ B _ := prodR (orarFunctor_car F1 A B) (orarFunctor_car F2 A B);
   orarFunctor_map A1 _ A2 _ B1 _ B2 _ fg :=
     prodO_map (orarFunctor_map F1 fg) (orarFunctor_map F2 fg)
 |}.
 Next Obligation.
-  intros F1 F2 A1 ? A2 ? B1 ? B2 ? n ???. by apply prodO_map_ne; apply orarFunctor_map_ne.
+  intros ? F1 F2 A1 ? A2 ? B1 ? B2 ? n ???. by apply prodO_map_ne; apply orarFunctor_map_ne.
 Qed.
-Next Obligation. by intros F1 F2 A ? B ? [??]; rewrite /= !orarFunctor_map_id. Qed.
+Next Obligation. by intros ? F1 F2 A ? B ? [??]; rewrite /= !orarFunctor_map_id. Qed.
 Next Obligation.
-  intros F1 F2 A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' [??]; simpl.
+  intros ? F1 F2 A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' [??]; simpl.
   by rewrite !orarFunctor_map_compose.
 Qed.
 Notation "F1 * F2" := (prodRF F1%ORF F2%ORF) : rFunctor_scope.
 
-#[export] Instance prodRF_contractive F1 F2 :
+#[export] Instance prodRF_contractive {SI: sidx} F1 F2 :
   OrarFunctorContractive F1 → OrarFunctorContractive F2 →
   OrarFunctorContractive (prodRF F1 F2). 
 Proof.
@@ -1363,22 +1382,22 @@ Proof.
     by apply prodO_map_ne; apply orarFunctor_map_contractive.
 Qed.
 
-Program Definition prodURF (F1 F2 : uorarFunctor) : uorarFunctor := {|
+Program Definition prodURF {SI: sidx} (F1 F2 : uorarFunctor) : uorarFunctor := {|
   uorarFunctor_car A _ B _ := prodUR (uorarFunctor_car F1 A B) (uorarFunctor_car F2 A B);
   uorarFunctor_map A1 _ A2 _ B1 _ B2 _ fg :=
     prodO_map (uorarFunctor_map F1 fg) (uorarFunctor_map F2 fg)
 |}.
 Next Obligation.
-  intros F1 F2 A1 ? A2 ? B1 ? B2 ? n ???. by apply prodO_map_ne; apply uorarFunctor_map_ne.
+  intros ? F1 F2 A1 ? A2 ? B1 ? B2 ? n ???. by apply prodO_map_ne; apply uorarFunctor_map_ne.
 Qed.
-Next Obligation. by intros F1 F2 A ? B ? [??]; rewrite /= !uorarFunctor_map_id. Qed.
+Next Obligation. by intros ? F1 F2 A ? B ? [??]; rewrite /= !uorarFunctor_map_id. Qed.
 Next Obligation.
-  intros F1 F2 A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' [??]; simpl.
+  intros ? F1 F2 A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' [??]; simpl.
   by rewrite !uorarFunctor_map_compose.
 Qed.
 Notation "F1 * F2" := (prodURF F1%UORF F2%UORF) : urFunctor_scope.
 
-#[export] Instance prodURF_contractive F1 F2 :
+#[export] Instance prodURF_contractive {SI: sidx} F1 F2 :
   uorarFunctorContractive F1 → uorarFunctorContractive F2 →
   uorarFunctorContractive (prodURF F1 F2).
 Proof.
@@ -1388,7 +1407,7 @@ Qed.
 
 (** ** CMRA for the option type *)
 Section option.
-  Context {A : ora}.
+  Context {SI: sidx} {A : ora}.
   Implicit Types a b : A.
   Implicit Types ma mb : option A.
   Local Arguments core _ _ !_ /.
@@ -1436,7 +1455,7 @@ Section option.
   Definition Some_valid a : ✓ Some a ↔ ✓ a := reflexivity _.
   Definition Some_validN a n : ✓{n} Some a ↔ ✓{n} a := reflexivity _.
   Definition Some_op a b : Some (a ⋅ b) = Some a ⋅ Some b := eq_refl.
-  Lemma Some_core `{OraTotal A} a : Some (core a) = core (Some a).
+  Lemma Some_core `{!OraTotal A} a : Some (core a) = core (Some a).
   Proof. rewrite /core /=. by destruct (ora_total a) as [? ->]. Qed.
   Lemma Some_op_opM a ma : Some a ⋅ ma = Some (a ⋅? ma).
   Proof. by destruct ma. Qed.
@@ -1569,8 +1588,8 @@ Section option.
       intros; eapply ora_validN_orderN; eauto.
     - intros [x|] [y|]; try done.
       * apply ora_order_orderN.
-      * split; auto. intros Hx; apply (Hx 0).
-      * split; auto. intros Hx; apply (Hx 0).
+      * split; auto. intros Hx; apply (Hx 0ᵢ).
+      * split; auto. intros Hx; apply (Hx 0ᵢ).
     - intros [x|] [cx|] [y|] Hcx; try done; simpl in *; simplify_eq.
       + inversion Hcx; subst.
         destruct (ora_pcore_order_op x cx y) as [z [Hz Hz']]; auto.
@@ -1646,9 +1665,9 @@ Section option.
   Lemma Some_order_2 a b : a ≼ₒ b → Some a ≼ₒ Some b.
   Proof. rewrite Some_order; eauto. Qed.
 
-  Lemma Some_orderN_total `{OraTotal A} n a b : Some a ≼ₒ{n} Some b ↔ a ≼ₒ{n} b.
+  Lemma Some_orderN_total `{!OraTotal A} n a b : Some a ≼ₒ{n} Some b ↔ a ≼ₒ{n} b.
   Proof. by rewrite Some_orderN. Qed.
-  Lemma Some_order_total `{OraTotal A} a b : Some a ≼ₒ Some b ↔ a ≼ₒ b.
+  Lemma Some_order_total `{!OraTotal A} a b : Some a ≼ₒ Some b ↔ a ≼ₒ b.
   Proof. by rewrite Some_order. Qed.
 
   Lemma Some_includedN_exclusive n a `{!OraExclusive a} b :
@@ -1673,16 +1692,16 @@ Section option.
   Proof.
     intros Hirr ?? [b|] [c|] ? EQ; inversion_clear EQ.
     - constructor. by apply (oracancelableN a).
-    - destruct (Hirr b); [|eauto using dist_le with lia].
-      by eapply (cmra_validN_op_l 0 a b), (cmra_validN_le n); last lia.
-    - destruct (Hirr c); [|symmetry; eauto using dist_le with lia].
-      by eapply (cmra_validN_le n); last lia.
+    - destruct (Hirr b); [|eauto using dist_le, SIdx.le_0_l].
+      by apply (cmra_validN_op_l 0ᵢ a b), (cmra_validN_le n), SIdx.le_0_l.
+    - destruct (Hirr c); [|symmetry; eauto using dist_le, SIdx.le_0_l].
+      by eapply (cmra_validN_le n), SIdx.le_0_l.
     - done.
   Qed.
 End option.
 
-Arguments optionR : clear implicits.
-Arguments optionUR : clear implicits.
+Arguments optionR {_} _.
+Arguments optionUR {_} _.
 
 (* Section option_prod. *)
 (*   Context {A B : ora}. *)
@@ -1710,7 +1729,7 @@ Arguments optionUR : clear implicits.
 (*   Proof. intros ?%Some_pair_included. by rewrite -(Some_included_total b1). Qed. *)
 (* End option_prod. *)
 
-#[export] Instance option_fmap_ora_morphism {A B : ora} (f: A → B) `{!OraMorphism f} :
+#[export] Instance option_fmap_ora_morphism {SI: sidx} {A B : ora} (f: A → B) `{!OraMorphism f} :
   OraMorphism (fmap f : option A → option B).
 Proof.
   split; first apply _.
@@ -1724,45 +1743,45 @@ Proof.
     + intros ?; apply None_increasing.
 Qed.
 
-Program Definition optionRF (F : OrarFunctor) : OrarFunctor := {|
+Program Definition optionRF {SI: sidx} (F : OrarFunctor) : OrarFunctor := {|
   orarFunctor_car A _ B _ := optionR (orarFunctor_car F A B);
   orarFunctor_map A1 _ A2 _ B1 _ B2 _ fg := optionO_map (orarFunctor_map F fg)
 |}.
 Next Obligation.
-  by intros F A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply optionO_map_ne, orarFunctor_map_ne.
+  by intros ? F A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply optionO_map_ne, orarFunctor_map_ne.
 Qed.
 Next Obligation.
-  intros F A ? B ? x. rewrite /= -{2}(option_fmap_id x).
+  intros ? F A ? B ? x. rewrite /= -{2}(option_fmap_id x).
   apply option_fmap_equiv_ext=>y; apply orarFunctor_map_id.
 Qed.
 Next Obligation.
-  intros F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x. rewrite /= -option_fmap_compose.
+  intros ? F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x. rewrite /= -option_fmap_compose.
   apply option_fmap_equiv_ext=>y; apply orarFunctor_map_compose.
 Qed.
 
-#[export] Instance optionRF_contractive F :
+#[export] Instance optionRF_contractive {SI: sidx} F :
   OrarFunctorContractive F → OrarFunctorContractive (optionRF F).
 Proof.
   by intros ? A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply optionO_map_ne, orarFunctor_map_contractive.
 Qed.
 
-Program Definition optionURF (F : OrarFunctor) : uorarFunctor := {|
+Program Definition optionURF {SI: sidx} (F : OrarFunctor) : uorarFunctor := {|
   uorarFunctor_car A _ B _ := optionUR (orarFunctor_car F A B);
   uorarFunctor_map A1 _ A2 _ B1 _ B2 _ fg := optionO_map (orarFunctor_map F fg)
 |}.
 Next Obligation.
-  by intros F A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply optionO_map_ne, orarFunctor_map_ne.
+  by intros ? F A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply optionO_map_ne, orarFunctor_map_ne.
 Qed.
 Next Obligation.
-  intros F A ? B ? x. rewrite /= -{2}(option_fmap_id x).
+  intros ? F A ? B ? x. rewrite /= -{2}(option_fmap_id x).
   apply option_fmap_equiv_ext=>y; apply orarFunctor_map_id.
 Qed.
 Next Obligation.
-  intros F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x. rewrite /= -option_fmap_compose.
+  intros ? F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x. rewrite /= -option_fmap_compose.
   apply option_fmap_equiv_ext=>y; apply orarFunctor_map_compose.
 Qed.
 
-#[export] Instance optionURF_contractive F :
+#[export] Instance optionURF_contractive {SI: sidx} F :
   OrarFunctorContractive F → uorarFunctorContractive (optionURF F).
 Proof.
   by intros ? A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply optionO_map_ne, orarFunctor_map_contractive.
@@ -1770,7 +1789,7 @@ Qed.
 
 (* Dependently-typed functions over a discrete domain *)
 Section discrete_fun_ora.
-  Context {A : Type} `{Hfin : Finite A} {B : A → uora}.
+  Context {SI: sidx} {A : Type} `{Hfin : Finite A} {B : A → uora}.
   Implicit Types f g : discrete_fun B.
 
   Instance discrete_fun_op : Op (discrete_fun B) := λ f g x, f x ⋅ g x.
@@ -1878,11 +1897,11 @@ Section discrete_fun_ora.
   Proof. intros ? f Hf x. by apply: discrete. Qed.
 End discrete_fun_ora.
 
-Arguments discrete_funR {_ _ _} _.
-Arguments discrete_funUR {_ _ _} _.
+Arguments discrete_funR {_ _ _ _} _.
+Arguments discrete_funUR {_ _ _ _} _.
 
 Global Instance discrete_fun_map_ora_morphism
-    `{Finite A} {B1 B2 : A → uora} (f : ∀ x, B1 x → B2 x) :
+   {SI: sidx} `{Finite A} {B1 B2 : A → uora} (f : ∀ x, B1 x → B2 x) :
   (∀ x, OraMorphism (f x)) → OraMorphism (discrete_fun_map f).
 Proof.
   intros Ho; split.
@@ -1894,25 +1913,25 @@ Proof.
     by apply discrete_fun_increasing.
 Qed.
 
-Program Definition discrete_funURF `{Finite C} (F : C → uorarFunctor) : uorarFunctor := {|
+Program Definition discrete_funURF {SI: sidx} `{Finite C} (F : C → uorarFunctor) : uorarFunctor := {|
   uorarFunctor_car A _ B _ := discrete_funUR (λ c, uorarFunctor_car (F c) A B);
   uorarFunctor_map A1 _ A2 _ B1 _ B2 _ fg := discrete_funO_map (λ c, uorarFunctor_map (F c) fg)
 |}.
 Next Obligation.
-  intros C ?? F A1 ? A2 ? B1 ? B2 ? n ?? g.
+  intros ? C ?? F A1 ? A2 ? B1 ? B2 ? n ?? g.
   by apply discrete_funO_map_ne=>?; apply uorarFunctor_map_ne.
 Qed.
 Next Obligation.
-  intros C ?? F A ? B ? g; simpl. rewrite -{2}(discrete_fun_map_id g).
+  intros ? C ?? F A ? B ? g; simpl. rewrite -{2}(discrete_fun_map_id g).
   apply discrete_fun_map_ext=> y; apply uorarFunctor_map_id.
 Qed.
 Next Obligation.
-  intros C ?? F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f1 f2 f1' f2' g. rewrite /=-discrete_fun_map_compose.
+  intros ? C ?? F A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f1 f2 f1' f2' g. rewrite /=-discrete_fun_map_compose.
   apply discrete_fun_map_ext=>y; apply uorarFunctor_map_compose.
 Qed.
-Global Instance discrete_funURF_contractive `{Finite C} (F : C → uorarFunctor) :
+Global Instance discrete_funURF_contractive {SI: sidx} `{Finite C} (F : C → uorarFunctor) :
   (∀ c, uorarFunctorContractive (F c)) → uorarFunctorContractive (discrete_funURF F).
 Proof.
-  intros ?? A1 ? A2 ? B1 ? B2 ? n ?? g.
+  intros ??? A1 ? A2 ? B1 ? B2 ? n ??.
   by apply discrete_funO_map_ne=>c; apply uorarFunctor_map_contractive.
 Qed.

--- a/theories/algebra/ora.v
+++ b/theories/algebra/ora.v
@@ -2,6 +2,7 @@ From iris.algebra Require Export ofe monoid cmra numbers.
 From stdpp Require Import finite.
 Set Default Proof Using "Type".
 
+Local Open Scope sidx_scope.
 (* The order of an ordered RA quantifies over [A], not [option A].  This means
    we do not get reflexivity.  However, if we used [option A], the following
    would no longer hold:

--- a/theories/algebra/ora.v
+++ b/theories/algebra/ora.v
@@ -49,8 +49,7 @@ Section mixin.
       ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{Sᵢ n} x ∧ z ≡{n}≡ y;
     (* OraOrder *)
     mixin_ora_dist_orderN n x y : x ≡{n}≡ y → x ≼ₒ{n} y;
-    (* FIXME Is this strong enough? *)
-    mixin_ora_orderN_S n x y : x ≼ₒ{Sᵢ n} y → x ≼ₒ{n} y;
+    mixin_ora_orderN_le n n' x y : x ≼ₒ{n} y → n' ≤ n → x ≼ₒ{n'} y;
     mixin_ora_orderN_trans n : Transitive (OraorderN n);
     mixin_ora_orderN_op n x x' y : x ≼ₒ{n} x' → x ⋅ y ≼ₒ{n} x' ⋅ y;
     mixin_ora_validN_orderN n x y : ✓{n} x → y ≼ₒ{n} x → ✓{n} y;
@@ -131,8 +130,8 @@ Section ora_mixin.
   Proof. apply (mixin_ora_extend _ (ora_mixin A)). Qed.
   Lemma ora_dist_orderN n x y : x ≡{n}≡ y → x ≼ₒ{n} y.
   Proof. apply (mixin_ora_dist_orderN _ (ora_mixin A)). Qed.
-  Lemma ora_orderN_S n x y : x ≼ₒ{Sᵢ n} y → x ≼ₒ{n} y.
-  Proof. apply (mixin_ora_orderN_S _ (ora_mixin A)). Qed.
+  Lemma ora_orderN_le n n' x y : x ≼ₒ{n} y → n' ≤ n → x ≼ₒ{n'} y.
+  Proof. apply (mixin_ora_orderN_le _ (ora_mixin A)). Qed.
   Global Instance ora_orderN_trans n : Transitive (@OraorderN SI A _ n).
   Proof. apply (mixin_ora_orderN_trans _ (ora_mixin A)). Qed.
   Lemma ora_orderN_op n x x' y : x ≼ₒ{n} x' → x ⋅ y ≼ₒ{n} x' ⋅ y.
@@ -414,19 +413,6 @@ Proof. intros Hyv [z ?]; setoid_subst; eauto using ora_valid_op_l. Qed.
 Lemma ora_validN_order n x y : ✓{n} y → x ≼ y → ✓{n} x.
 Proof. intros Hyv [z ?]; setoid_subst; eauto using ora_validN_op_l. Qed.*)
 Local Set Primitive Projections.
-Lemma ora_orderN_le n n' x y : x ≼ₒ{n} y → n' ≤ n → x ≼ₒ{n'} y.
-Proof.
-  induction (SIdx.lt_wf n) as [n _ IH]; intros.
-  rewrite SIdx.le_lteq in H0.  destruct H0 as [?|Hlt].
-  2: { subst. done. }
-  (* case on whether n has a predecessor *)
-  destruct (SIdx.weak_case n).
-  - destruct s as [pred_n ->].
-    eapply (IH pred_n). 
-    { apply SIdx.lt_succ_diag_r. }
-    { by apply ora_orderN_S. }
-    rewrite -SIdx.lt_succ_r //.
-  - Admitted.
 
 (* Lemma ora_pcore_order_op' x cx y : *)
 (*   pcore x ≡ Some cx → ∃ cxy, pcore (x ⋅ y) = Some cxy ∧ cx ≼ₒ cxy. *)
@@ -807,7 +793,7 @@ Section ora_total.
   Context (extend_order : ∀ n (x y : A),
               ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{Sᵢ n} x ∧ z ≡{n}≡ y).
   Context (dist_orderN : ∀ n (x y : A), x ≡{n}≡ y → x ≼ₒ{n} y).
-  Context (orderN_S : ∀ n (x y : A), x ≼ₒ{Sᵢ n} y → x ≼ₒ{n} y).
+  Context (orderN_le : ∀ n n' (x y : A), x ≼ₒ{n} y → n' ≤ n → x ≼ₒ{n'} y).
   Context (OrderN_trans : ∀ n, Transitive (OraorderN n)).
   Context (orderN_op : ∀ n (x x' y : A), x ≼ₒ{n} x' → x ⋅ y ≼ₒ{n} x' ⋅ y).
   Context (validN_orderN : ∀ n (x y : A), ✓{n} x → y ≼ₒ{n} x → ✓{n} y).
@@ -1256,7 +1242,7 @@ Section prod.
       destruct (ora_extend n x2 y2) as [z2 [? ?]]; auto.
       exists (z1, z2); done.
     - intros ??? [??]; split; by apply ora_dist_orderN.
-    - intros ??? [??]; split; by apply ora_orderN_S.
+    - intros ??? ?[??]; split;  eapply ora_orderN_le; eauto.
     - intros ???? [??]; split; by apply ora_orderN_op.
     - intros ??? [??] [??]; split; by eapply ora_validN_orderN.
     - intros ? ?; split.
@@ -1576,8 +1562,8 @@ Section option.
     - intros n [x|] [y|]; try (by inversion 1).
       intros Hxy. apply ora_dist_orderN.
       by apply Some_dist_inj.
-    - intros n [x|] [y|]; intros Hxy; try done.
-        by apply ora_orderN_S.
+    - intros n n' [x|] [y|]; intros Hxy; try done.
+        by apply ora_orderN_le.
     - intros n [x|] [y|] [z|]; intros Hxy Hyz; try done.
       * eapply ora_orderN_trans; eauto.
       * eapply ora_increasing_closed; eauto.
@@ -1857,7 +1843,7 @@ Section discrete_fun_ora.
           first (by apply Hf); first by apply Hfg. exists z; eauto. }
       exists g'; naive_solver.
     - intros n f g Hfg x. apply ora_dist_orderN; apply Hfg.
-    - intros n f g Hfg x. apply ora_orderN_S; apply Hfg.
+    - intros n f g Hfg x ? ?. eapply ora_orderN_le; eauto.
     - intros n f g h Hfg Hgh x.
       eapply ora_orderN_trans; first eapply Hfg; apply Hgh.
     - intros n f g h Hfg x. rewrite /op /discrete_fun_op /=.

--- a/theories/algebra/ora.v
+++ b/theories/algebra/ora.v
@@ -13,11 +13,11 @@ Notation "(≼ₒ)" := Oraorder (only parsing) : stdpp_scope.
 #[export] Hint Extern 0 (_ ≼ₒ _) => reflexivity : core.
 #[export] Instance: Params (@Oraorder) 2 := {}.
 
-Class OraOrderN A := OraorderN : nat → A → A → Prop.
+Class OraOrderN {SI : sidx} A := OraorderN : SI → A → A → Prop.
 Notation "x ≼ₒ{ n } y" := (OraorderN n x y)
   (at level 70, n at next level, format "x  ≼ₒ{ n }  y") : stdpp_scope.
 (*Notation "(≼ₒ{ n })" := (OraorderN n) (only parsing) : stdpp_scope.*)
-#[export] Instance: Params (@OraorderN) 3 := {}.
+#[export] Instance: Params (@OraorderN) 4 := {}.
 #[export] Hint Extern 0 (_ ≼ₒ{_} _) => reflexivity : core.
 
 Class Increasing `{Op A, OraOrder A} (x : A) := increasing : ∀ y, y ≼ₒ x ⋅ y.
@@ -27,13 +27,13 @@ Arguments increasing {_ _ _} _ {_}.
 Arguments increasingN {_ _ _} _ _ {_}.*)
 
 Section mixin.
-  Context (A : Type).
+  Context {SI : sidx} (A : Type).
 
   Implicit Types (x : A).
   Local Set Primitive Projections.
 
-  Record OraMixin `{Dist A, Equiv A, PCore A, Op A, Valid A, ValidN A,
-                      OraOrder A, OraOrderN A} := {
+  Record OraMixin `{!Dist A, !Equiv A, !PCore A, !Op A, !Valid A, !ValidN A,
+                      !OraOrder A, !OraOrderN A} := {
     (* setoids *)
     mixin_ora_pcore_increasing x cx : pcore x = Some cx → Increasing cx;
     mixin_ora_increasing_closed n x y : Increasing x → x ≼ₒ{n} y → Increasing y;
@@ -43,12 +43,12 @@ Section mixin.
     (* This follows from ora_extend + cmra_extend. *)
     mixin_ora_op_extend n x y1 y2 :
       ✓{n} x → y1 ⋅ y2 ≼ₒ{n} x →
-      ∃ z1 z2, z1 ⋅ z2 ≼ₒ{S n} x ∧ z1 ≡{n}≡ y1 ∧ z2 ≡{n}≡ y2;
+      ∃ z1 z2, z1 ⋅ z2 ≼ₒ{Sᵢ n} x ∧ z1 ≡{n}≡ y1 ∧ z2 ≡{n}≡ y2;
     mixin_ora_extend n x y :
-      ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{S n} x ∧ z ≡{n}≡ y;
+      ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{Sᵢ n} x ∧ z ≡{n}≡ y;
     (* OraOrder *)
     mixin_ora_dist_orderN n x y : x ≡{n}≡ y → x ≼ₒ{n} y;
-    mixin_ora_orderN_S n x y : x ≼ₒ{S n} y → x ≼ₒ{n} y;
+    mixin_ora_orderN_S n x y : x ≼ₒ{Sᵢ n} y → x ≼ₒ{n} y;
     mixin_ora_orderN_trans n : Transitive (OraorderN n);
     mixin_ora_orderN_op n x x' y : x ≼ₒ{n} x' → x ⋅ y ≼ₒ{n} x' ⋅ y;
     mixin_ora_validN_orderN n x y : ✓{n} x → y ≼ₒ{n} x → ✓{n} y;
@@ -59,7 +59,7 @@ Section mixin.
 End mixin.
 
 (** Bundled version *)
-Structure ora := Ora' {
+Structure ora {SI : sidx} := Ora' {
   ora_car :> Type;
   ora_equiv : Equiv ora_car;
   ora_dist : Dist ora_car;
@@ -73,7 +73,7 @@ Structure ora := Ora' {
   ora_cmra_mixin : CmraMixin ora_car;
   ora_mixin : OraMixin ora_car;
 }.
-Arguments Ora' _ {_ _ _ _ _ _ _ _} _ _ _.
+Arguments Ora' {_} _ {_ _ _ _ _ _ _ _} _ _ _.
 (* Given [m : OraMixin A], the notation [Ora A m] provides a smart
 constructor, which uses [ofe_mixin_of A] to infer the canonical OFE mixin of
 the type [A], so that it does not have to be given manually. *)
@@ -98,18 +98,18 @@ Add Printing Constructor ora.
 #[export] Hint Extern 0 (ValidN _) => eapply (@ora_validN _) : typeclass_instances.
 #[export] Hint Extern 0 (OraOrder _) => eapply (@ora_order _) : typeclass_instances.
 #[export] Hint Extern 0 (OraOrderN _) => eapply (@ora_orderN _) : typeclass_instances.
-Coercion ora_ofeO (A : ora) : ofe := Ofe A (ora_ofe_mixin A).
+Coercion ora_ofeO {SI : sidx} (A : ora) : ofe := Ofe A (ora_ofe_mixin A).
 Canonical Structure ora_ofeO.
-Coercion ora_cmraR (A : ora) : cmra := Cmra' A (ora_ofe_mixin A) (ora_cmra_mixin A).
+Coercion ora_cmraR {SI : sidx} (A : ora) : cmra := Cmra A (ora_cmra_mixin A).
 Canonical Structure ora_cmraR.
 
-Definition ora_mixin_of' A {Ac : ora} (f : Ac → A) : OraMixin Ac := ora_mixin Ac.
+Definition ora_mixin_of' {SI : sidx} A {Ac : ora} (f : Ac → A) : OraMixin Ac := ora_mixin Ac.
 Notation ora_mixin_of A :=
   ltac:(let H := eval hnf in (ora_mixin_of' A id) in exact H) (only parsing).
 
 (** Lifting properties from the mixin *)
 Section ora_mixin.
-  Context {A : ora}.
+  Context {SI : sidx} {A : ora}.
   Implicit Types x y : A.
   Global Instance ora_assoc : Assoc (≡@{A} ) (⋅) := cmra_assoc.
   Global Instance ora_comm : Comm (≡@{A} ) (⋅) := cmra_comm.
@@ -122,16 +122,16 @@ Section ora_mixin.
   Proof. apply (mixin_ora_pcore_monoN _ (ora_mixin A)). Qed.
   Lemma ora_op_extend n x y1 y2 :
     ✓{n} x → y1 ⋅ y2 ≼ₒ{n} x →
-    ∃ z1 z2, z1 ⋅ z2 ≼ₒ{S n} x ∧ z1 ≡{n}≡ y1 ∧ z2 ≡{n}≡ y2.
+    ∃ z1 z2, z1 ⋅ z2 ≼ₒ{Sᵢ n} x ∧ z1 ≡{n}≡ y1 ∧ z2 ≡{n}≡ y2.
   Proof. apply (mixin_ora_op_extend _ (ora_mixin A)). Qed.
   Lemma ora_extend n x y :
-      ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{S n} x ∧ z ≡{n}≡ y.
+      ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{Sᵢ n} x ∧ z ≡{n}≡ y.
   Proof. apply (mixin_ora_extend _ (ora_mixin A)). Qed.
   Lemma ora_dist_orderN n x y : x ≡{n}≡ y → x ≼ₒ{n} y.
   Proof. apply (mixin_ora_dist_orderN _ (ora_mixin A)). Qed.
-  Lemma ora_orderN_S n x y : x ≼ₒ{S n} y → x ≼ₒ{n} y.
+  Lemma ora_orderN_S n x y : x ≼ₒ{Sᵢ n} y → x ≼ₒ{n} y.
   Proof. apply (mixin_ora_orderN_S _ (ora_mixin A)). Qed.
-  Global Instance ora_orderN_trans n : Transitive (@OraorderN A _ n).
+  Global Instance ora_orderN_trans n : Transitive (@OraorderN SI A _ n).
   Proof. apply (mixin_ora_orderN_trans _ (ora_mixin A)). Qed.
   Lemma ora_orderN_op n x x' y : x ≼ₒ{n} x' → x ⋅ y ≼ₒ{n} x' ⋅ y.
   Proof. apply (mixin_ora_orderN_op _ (ora_mixin A)). Qed.
@@ -145,48 +145,49 @@ Section ora_mixin.
 End ora_mixin.
 
 
-Definition OraopM {A : ora} (x : A) (my : option A) :=
+Definition OraopM {SI : sidx} {A : ora} (x : A) (my : option A) :=
   match my with Some y => x ⋅ y | None => x end.
 Infix "⋅?" := OraopM (at level 50, left associativity) : stdpp_scope.
 
 (** * CoreId elements *)
-Class OraCoreId {A : ora} (x : A) := oracore_id : pcore x ≡ Some x.
-Arguments oracore_id {_} _ {_}.
-#[export] Hint Mode OraCoreId + ! : typeclass_instances.
-#[export] Instance: Params (@OraCoreId) 1 := {}.
+Class OraCoreId {SI : sidx} {A : ora} (x : A) := oracore_id : pcore x ≡ Some x.
+Arguments oracore_id {_ _} _ {_}.
+#[export] Hint Mode OraCoreId - + ! : typeclass_instances.
+#[export] Instance: Params (@OraCoreId) 2 := {}.
 
 (** * Exclusive elements (i.e., elements that cannot have a frame). *)
-Class OraExclusive {A : ora} (x : A) := oraexclusive0_l y : ✓{0} (x ⋅ y) → False.
-Arguments oraexclusive0_l {_} _ {_} _ _.
-#[export] Hint Mode OraExclusive + ! : typeclass_instances.
-#[export] Instance: Params (@OraExclusive) 1 := {}.
+Class OraExclusive {SI : sidx} {A : ora} (x : A) := oraexclusive0_l y : ✓{0ᵢ} (x ⋅ y) → False.
+Arguments oraexclusive0_l {_ _} _ {_} _ _.
+
+#[export] Hint Mode OraExclusive - + ! : typeclass_instances.
+#[export] Instance: Params (@OraExclusive) 2 := {}.
 
 (** * Cancelable elements. *)
-Class OraCancelable {A : ora} (x : A) :=
+Class OraCancelable {SI : sidx} {A : ora} (x : A) :=
   oracancelableN n y z : ✓{n}(x ⋅ y) → x ⋅ y ≡{n}≡ x ⋅ z → y ≡{n}≡ z.
-Arguments oracancelableN {_} _ {_} _ _ _ _.
-#[export] Hint Mode OraCancelable + ! : typeclass_instances.
-#[export] Instance: Params (@OraCancelable) 1 := {}.
+Arguments oracancelableN {_ _} _ {_} _ _ _ _.
+#[export] Hint Mode OraCancelable - + ! : typeclass_instances.
+#[export] Instance: Params (@OraCancelable) 2 := {}.
 
 (** * Identity-free elements. *)
-Class OraIdFree {A : ora} (x : A) :=
-  oraid_free0_r y : ✓{0}x → x ⋅ y ≡{0}≡ x → False.
-Arguments oraid_free0_r {_} _ {_} _ _.
-#[export] Hint Mode OraIdFree + ! : typeclass_instances.
-#[export] Instance: Params (@OraIdFree) 1 := {}.
+Class OraIdFree {SI : sidx} {A : ora} (x : A) :=
+  oraid_free0_r y : ✓{0ᵢ}x → x ⋅ y ≡{0ᵢ}≡ x → False.
+Arguments oraid_free0_r {_ _} _ {_} _ _.
+#[export] Hint Mode OraIdFree - + ! : typeclass_instances.
+#[export] Instance: Params (@OraIdFree) 2 := {}.
 
 (** * CMRAs whose core is total *)
 (** The function [core] may return a dummy when used on CMRAs without total
 core. *)
-Class OraTotal (A : ora) := ora_total (x : A) : is_Some (pcore x).
-#[export] Hint Mode OraTotal ! : typeclass_instances.
+Class OraTotal {SI : sidx} (A : ora) := ora_total (x : A) : is_Some (pcore x).
+#[export] Hint Mode OraTotal - ! : typeclass_instances.
 
-Record UoraMixin A `{Dist A, Equiv A, Unit A} := {
+Record UoraMixin {SI : sidx} A `{!Dist A, !Equiv A, !Unit A} := {
     (* needed to make emp timeless *)
-    mixin_uora_unit_discrete (y : A) : ε ≡{0}≡ y → ε ≡ y;
+    mixin_uora_unit_discrete (y : A) : ε ≡{0ᵢ}≡ y → ε ≡ y;
   }.
 
-Structure uora := Uora' {
+Structure uora {SI : sidx} := Uora' {
   uora_car :> Type;
   uora_equiv : Equiv uora_car;
   uora_dist : Dist uora_car;
@@ -203,7 +204,7 @@ Structure uora := Uora' {
   uora_ucmra_mixin : UcmraMixin uora_car;
   uora_mixin : UoraMixin uora_car;
 }.
-Arguments Uora' _ {_ _ _ _ _ _ _ _ _} _ _ _ _.
+Arguments Uora' {_} _ {_ _ _ _ _ _ _ _ _} _ _ _ _.
 Notation Uora A m n :=
   (Uora' A (ofe_mixin_of A%type) (cmra_mixin_of A%type) (ora_mixin_of A%type) m n) (only parsing).
 Arguments uora_car : simpl never.
@@ -222,44 +223,44 @@ Arguments uora_ucmra_mixin : simpl never.
 Arguments uora_mixin : simpl never.
 Add Printing Constructor uora.
 #[export] Hint Extern 0 (Unit _) => eapply (@uora_unit _) : typeclass_instances.
-Coercion uora_ofeO (A : uora) : ofe := Ofe A (uora_ofe_mixin A).
+Coercion uora_ofeO {SI : sidx} (A : uora) : ofe := Ofe A (uora_ofe_mixin A).
 Canonical Structure uora_ofeO.
-Coercion uora_oraR (A : uora) : ora :=
+Coercion uora_oraR {SI : sidx} (A : uora) : ora :=
   Ora' A (uora_ofe_mixin A) (uora_cmra_mixin A) (uora_ora_mixin A).
 Canonical Structure uora_oraR.
-Coercion uora_ucmraR (A : uora) : ucmra :=
+Coercion uora_ucmraR {SI : sidx} (A : uora) : ucmra :=
   Ucmra' A (uora_ofe_mixin A) (uora_cmra_mixin A) (uora_ucmra_mixin A).
 Canonical Structure uora_ucmraR.
 
 (** Lifting properties from the mixin *)
 Section uora_mixin.
-  Context {A : uora}.
+  Context {SI : sidx} {A : uora}.
   Implicit Types x y : A.
   Global Instance uora_unit_left_id : LeftId (≡) ε (@op A _).
   Proof. apply (mixin_ucmra_unit_left_id _ (ucmra_mixin A)). Qed.
 End uora_mixin.
 
 (** * Discrete CMRAs *)
-Class OraDiscrete (A : ora) := {
+Class OraDiscrete {SI : sidx} (A : ora) := {
   ora_discrete_ofe_discrete :: OfeDiscrete A;
-  ora_discrete_valid (x : A) : ✓{0} x → ✓ x;
-  ora_discrete_order (x y: A) : x ≼ₒ{0} y → x ≼ₒ y
+  ora_discrete_valid (x : A) : ✓{0ᵢ} x → ✓ x;
+  ora_discrete_order (x y: A) : x ≼ₒ{0ᵢ} y → x ≼ₒ y
 }.
-#[export] Hint Mode OraDiscrete ! : typeclass_instances.
+#[export] Hint Mode OraDiscrete - ! : typeclass_instances.
 
 (** * Morphisms *)
-Class OraMorphism {A B : ora} (f : A → B) := {
+Class OraMorphism {SI : sidx} {A B : ora} (f : A → B) := {
   ora_cmra_morphism :: CmraMorphism f;
   ora_morphism_orderN n x y : x ≼ₒ{n} y  → f x ≼ₒ{n} f y;
   ora_morphism_increasing x : Increasing x → Increasing (f x);
 }.
-Arguments ora_cmra_morphism {_ _} _ {_}.
-Arguments ora_morphism_orderN {_ _} _ {_} _ _ _.
-Arguments ora_morphism_increasing {_ _} _ _ _.
+Arguments ora_cmra_morphism {_ _ _} _ {_}.
+Arguments ora_morphism_orderN {_ _ _} _ {_} _ _ _.
+Arguments ora_morphism_increasing {_ _ _} _ _ _.
 
 (** * Properties **)
 Section ora.
-Context {A : ora}.
+Context {SI : sidx} {A : ora}.
 Implicit Types x y z : A.
 Implicit Types xs ys zs : list A.
 
@@ -267,7 +268,7 @@ Implicit Types xs ys zs : list A.
 Global Instance ora_order_trans: Transitive (@Oraorder A _).
 Proof.
   intros x y z Hxy Hyz; apply ora_order_orderN => n;
-    eapply (@ora_orderN_trans _ _ _ y); by eapply ora_order_orderN.
+    eapply (@ora_orderN_trans _ _ _ _ y); by eapply ora_order_orderN.
 Qed.
 Global Instance ora_pcore_ne' : NonExpansive (@pcore A _) := cmra_pcore_ne'.
 Lemma ora_pcore_proper x y cx :
@@ -281,8 +282,8 @@ Global Instance ora_op_ne' : NonExpansive2 (@op A _).
 Proof. intros n x1 x2 Hx y1 y2 Hy. by rewrite Hy (comm _ x1) Hx (comm _ y2). Qed.
 Global Instance ora_op_proper' : Proper ((≡) ==> (≡) ==> (≡)) (@op A _).
 Proof. apply (ne_proper_2 _). Qed.
-Global Instance ora_validN_ne' n : Proper (dist n ==> iff) (@validN A _ n) | 1 := cmra_validN_ne' n.
-Global Instance ora_validN_proper n : Proper ((≡) ==> iff) (@validN A _ n) | 1 := cmra_validN_proper n.
+Global Instance ora_validN_ne' n : Proper (dist n ==> iff) (@validN SI A _ n) | 1 := cmra_validN_ne' n.
+Global Instance ora_validN_proper n : Proper ((≡) ==> iff) (@validN SI A _ n) | 1 := cmra_validN_proper n.
 
 Lemma ora_order_op x x' y : x ≼ₒ x' → x ⋅ y ≼ₒ x' ⋅ y.
 Proof.
@@ -292,7 +293,7 @@ Qed.
 
 Global Instance ora_valid_proper : Proper ((≡) ==> iff) (@valid A _) := cmra_valid_proper.
 Global Instance ora_orderN_ne n :
-  Proper (dist n ==> dist n ==> iff) (@OraorderN A _ n) | 1.
+  Proper (dist n ==> dist n ==> iff) (@OraorderN SI A _ n) | 1.
 Proof.
   intros x x' Hx y y' Hy. split.
   - intros Hxy. etrans; first apply ora_dist_orderN; first by rewrite -Hx.
@@ -301,7 +302,7 @@ Proof.
     etrans; first done. by apply ora_dist_orderN.
 Qed.
 Global Instance ora_orderN_proper n :
-  Proper ((≡) ==> (≡) ==> iff) (@OraorderN A _ n) | 1.
+  Proper ((≡) ==> (≡) ==> iff) (@OraorderN SI A _ n) | 1.
 Proof.
   intros x x' Hx y y' Hy; revert Hx Hy; rewrite !equiv_dist=> Hx Hy.
   by rewrite (Hx n) (Hy n).
@@ -316,7 +317,7 @@ Proof.
   - eapply ora_orderN_proper; eauto.
 Qed.
 Global Instance ora_orderN_properN n :
-  Proper (flip (OraorderN n) ==> (OraorderN n) ==> impl) (@OraorderN A _ n) | 1.
+  Proper (flip (OraorderN n) ==> (OraorderN n) ==> impl) (@OraorderN SI A _ n) | 1.
 Proof.
   intros x x' Hx y y' Hy Hz.
   etrans; first apply Hx. etrans; eauto.
@@ -327,18 +328,18 @@ Proof.
   intros x x' Hx y y' Hy Hz.
   etrans; first apply Hx. etrans; eauto.
 Qed.
-Global Instance ora_opM_ne : NonExpansive2 (@OraopM A).
+Global Instance ora_opM_ne : NonExpansive2 (@OraopM SI A).
 Proof. destruct 2; by ofe_subst. Qed.
-Global Instance ora_opM_proper : Proper ((≡) ==> (≡) ==> (≡)) (@OraopM A).
+Global Instance ora_opM_proper : Proper ((≡) ==> (≡) ==> (≡)) (@OraopM SI A).
 Proof. destruct 2; by setoid_subst. Qed.
 
-Global Instance CoreId_proper : Proper ((≡) ==> iff) (@OraCoreId A).
+Global Instance CoreId_proper : Proper ((≡) ==> iff) (@OraCoreId SI A).
 Proof. solve_proper. Qed.
-Global Instance Exclusive_proper : Proper ((≡) ==> iff) (@OraExclusive A).
+Global Instance Exclusive_proper : Proper ((≡) ==> iff) (@OraExclusive SI A).
 Proof. intros x y Hxy. rewrite /OraExclusive. by setoid_rewrite Hxy. Qed.
-Global Instance Cancelable_proper : Proper ((≡) ==> iff) (@OraCancelable A).
+Global Instance Cancelable_proper : Proper ((≡) ==> iff) (@OraCancelable SI A).
 Proof. intros x y Hxy. rewrite /OraCancelable. by setoid_rewrite Hxy. Qed.
-Global Instance IdFree_proper : Proper ((≡) ==> iff) (@OraIdFree A).
+Global Instance IdFree_proper : Proper ((≡) ==> iff) (@OraIdFree SI A).
 Proof. intros x y Hxy. rewrite /OraIdFree. by setoid_rewrite Hxy. Qed.
 
 (** ** Op *)
@@ -389,11 +390,13 @@ Qed.
 
 (** ** Exclusive elements *)
 Lemma OraexclusiveN_l n x `{!OraExclusive x} y : ✓{n} (x ⋅ y) → False.
-Proof. intros. eapply (oraexclusive0_l x y), cmra_validN_le; eauto with lia. Qed.
+Proof. intros. eapply (oraexclusive0_l x y), cmra_validN_le; eauto with lia.
+apply SIdx.le_0_l.
+Qed.
 Lemma OraexclusiveN_r n x `{!OraExclusive x} y : ✓{n} (y ⋅ x) → False.
 Proof. rewrite comm. by apply OraexclusiveN_l. Qed.
 Lemma Oraexclusive_l x `{!OraExclusive x} y : ✓ (x ⋅ y) → False.
-Proof. by move /cmra_valid_validN /(_ 0) /oraexclusive0_l. Qed.
+Proof. by move /cmra_valid_validN /(_ 0ᵢ) /oraexclusive0_l. Qed.
 Lemma Oraexclusive_r x `{!OraExclusive x} y : ✓ (y ⋅ x) → False.
 Proof. rewrite comm. by apply Oraexclusive_l. Qed.
 Lemma OraexclusiveN_opM n x `{!OraExclusive x} my : ✓{n} (x ⋅? my) → my = None.
@@ -408,9 +411,9 @@ Proof. intros [? ->]. by apply Oraexclusive_l. Qed.
 Proof. intros Hyv [z ?]; setoid_subst; eauto using ora_valid_op_l. Qed.
 Lemma ora_validN_order n x y : ✓{n} y → x ≼ y → ✓{n} x.
 Proof. intros Hyv [z ?]; setoid_subst; eauto using ora_validN_op_l. Qed.*)
-
-Lemma ora_orderN_le n n' x y : x ≼ₒ{n} y → n' ≤ n → x ≼ₒ{n'} y.
-Proof. induction 2; auto using ora_orderN_S. Qed.
+Local Set Primitive Projections.
+Lemma ora_orderN_le n n' x y : x ≼ₒ{n} y → (n' ≤ n)%sidx → x ≼ₒ{n'} y.
+Proof. intros ? H. induction H.  induction 2; auto using ora_orderN_S. Qed.
 
 (* Lemma ora_pcore_order_op' x cx y : *)
 (*   pcore x ≡ Some cx → ∃ cxy, pcore (x ⋅ y) = Some cxy ∧ cx ≼ₒ cxy. *)
@@ -787,11 +790,11 @@ Section ora_total.
   Context (core_monoN : ∀ n x y, x ≼ₒ{n} y → core x ≼ₒ{n} core y).
   Context (op_extend : ∀ (n : nat) (x y1 y2 : A),
               ✓{n} x → y1 ⋅ y2 ≼ₒ{n} x →
-              ∃ z1 z2, z1 ⋅ z2 ≼ₒ{S n} x ∧ z1 ≡{n}≡ y1 ∧ z2 ≡{n}≡ y2).
+              ∃ z1 z2, z1 ⋅ z2 ≼ₒ{Sᵢ n} x ∧ z1 ≡{n}≡ y1 ∧ z2 ≡{n}≡ y2).
   Context (extend_order : ∀ (n : nat) (x y : A),
-              ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{S n} x ∧ z ≡{n}≡ y).
+              ✓{n} x → y ≼ₒ{n} x → ∃ z, z ≼ₒ{Sᵢ n} x ∧ z ≡{n}≡ y).
   Context (dist_orderN : ∀ (n : nat) (x y : A), x ≡{n}≡ y → x ≼ₒ{n} y).
-  Context (orderN_S : ∀ (n : nat) (x y : A), x ≼ₒ{S n} y → x ≼ₒ{n} y).
+  Context (orderN_S : ∀ (n : nat) (x y : A), x ≼ₒ{Sᵢ n} y → x ≼ₒ{n} y).
   Context (OrderN_trans : ∀ n : nat, Transitive (OraorderN n)).
   Context (orderN_op : ∀ (n : nat) (x x' y : A), x ≼ₒ{n} x' → x ⋅ y ≼ₒ{n} x' ⋅ y).
   Context (validN_orderN : ∀ (n : nat) (x y : A), ✓{n} x → y ≼ₒ{n} x → ✓{n} y).
@@ -1819,7 +1822,7 @@ Section discrete_fun_ora.
     - intros n f f1 f2 Hf Hf12.
 (*      assert (FUN := λ x, ora_op_extend n (f x) (f1 x) (f2 x) (Hf x) (Hf12 x)). *)
       destruct (finite_choice (λ x (yy : B x * B x),
-        yy.1 ⋅ yy.2 ≼ₒ{S n} f x ∧ yy.1 ≡{n}≡ f1 x ∧ yy.2 ≡{n}≡ f2 x)) as [gg Hgg].
+        yy.1 ⋅ yy.2 ≼ₒ{Sᵢ n} f x ∧ yy.1 ≡{n}≡ f1 x ∧ yy.2 ≡{n}≡ f2 x)) as [gg Hgg].
       { intros x; simpl.
         destruct (ora_op_extend n (f x) (f1 x) (f2 x)) as (z1&z2&Hz);
           first (by apply Hf); first by apply Hf12.
@@ -1827,7 +1830,7 @@ Section discrete_fun_ora.
       exists (λ x, (gg x).1), (λ x, (gg x).2); naive_solver.
     - intros n f g Hf Hfg.
 (*      assert (FUN := λ x, ora_extend n (f x) (g x) (Hf x) (Hfg x)). *)
-      destruct (finite_choice (λ x (y : B x), y ≼ₒ{S n} f x ∧ y ≡{n}≡ g x))
+      destruct (finite_choice (λ x (y : B x), y ≼ₒ{Sᵢ n} f x ∧ y ≡{n}≡ g x))
         as [g' Hg'].
       { intros x; simpl.
         destruct (ora_extend n (f x) (g x)) as (z&Hz);

--- a/theories/algebra/osum.v
+++ b/theories/algebra/osum.v
@@ -6,14 +6,14 @@ Local Arguments csum_pcore_instance _ _ !_/.
 Local Arguments cmra_car _ /.
 Local Arguments cmra_pcore _ / _.
 Local Arguments ora_pcore _ !_ /.
-Local Arguments validN _ _ _ !_ /.
+Local Arguments validN _ _ _ _ !_ /.
 Local Arguments valid _ _  !_ /.
 Local Arguments cmra_validN _ / _ _.
-Local Arguments ora_validN _ _ !_ /.
+Local Arguments ora_validN _ _ _ !_ /.
 Local Arguments ora_valid _  !_ /.
 
 Section ora.
-Context {A B : ora}.
+Context {SI : sidx} {A B : ora}.
 Implicit Types a : A.
 Implicit Types b : B.
 
@@ -22,7 +22,7 @@ Instance csum_order : OraOrder (csum A B) := λ x y,
   match x, y with
   | Cinl a, Cinl a' => a ≼ₒ a'
   | Cinr b, Cinr b' => b ≼ₒ b'
-  | _, CsumBot => True
+  | _, CsumInvalid => True
   | _, _ => False
   end.
 
@@ -30,12 +30,12 @@ Instance csum_orderN : OraOrderN (csum A B) := λ n x y,
   match x, y with
   | Cinl a, Cinl a' => a ≼ₒ{n} a'
   | Cinr b, Cinr b' => b ≼ₒ{n} b'
-  | _, CsumBot => True
+  | _, CsumInvalid => True
   | _, _ => False
   end.
 
 Lemma csum_order' x y :
-  x ≼ₒ y ↔ y = CsumBot ∨ (∃ a a', x = Cinl a ∧ y = Cinl a' ∧ a ≼ₒ a')
+  x ≼ₒ y ↔ y = CsumInvalid ∨ (∃ a a', x = Cinl a ∧ y = Cinl a' ∧ a ≼ₒ a')
                        ∨ (∃ b b', x = Cinr b ∧ y = Cinr b' ∧ b ≼ₒ b').
 Proof.
   destruct x; destruct y; split; rewrite /Oraorder /=; intuition;
@@ -47,7 +47,7 @@ Proof.
 Qed.
 
 Lemma csum_orderN' n x y :
-  x ≼ₒ{n} y ↔ y = CsumBot ∨ (∃ a a', x = Cinl a ∧ y = Cinl a' ∧ a ≼ₒ{n} a')
+  x ≼ₒ{n} y ↔ y = CsumInvalid ∨ (∃ a a', x = Cinl a ∧ y = Cinl a' ∧ a ≼ₒ{n} a')
                           ∨ (∃ b b', x = Cinr b ∧ y = Cinr b' ∧ b ≼ₒ{n} b').
 Proof.
   destruct x; destruct y; split; rewrite /OraorderN /=; intuition;
@@ -58,7 +58,7 @@ Proof.
     try (right; right; eauto; fail).
 Qed.
 
-Lemma Increasing_CsumBot : Increasing CsumBot.
+Lemma Increasing_CsumInvalid : Increasing CsumInvalid.
 Proof. intros [?|?|]; done. Qed.
 
 Lemma Increasing_cinl a : Increasing a ↔ Increasing (Cinl a).
@@ -117,7 +117,7 @@ Proof.
       exists (Cinr z); repeat split; by try constructor.
   - intros n [xl|xr|] [yl|yr|] Hyx; inversion Hyx; simplify_eq; try done;
       apply ora_dist_orderN; auto.
-  - intros n [xl|xr|] [yl|yr|] Hyx; try done; apply ora_orderN_S; auto.
+  - intros n n' [xl|xr|] [yl|yr|] Hyx; try done; apply ora_orderN_le; auto.
   - intros n [xl|xr|] [yl|yr|] [zl|zr|] Hxy Hyz; try done;
         eapply ora_orderN_trans; eauto.
   - intros n [xl|xr|] [x'l|x'r|] [yl|yr|] Hxx'; try done; auto;
@@ -125,8 +125,8 @@ Proof.
   - intros n [xl|xr|] [yl|yr|] Hx Hyx; try done;
       eapply ora_validN_orderN; eauto; apply Hx.
   - intros [xl|xr|] [yl|yr|]; split => Hx; try intros n;
-    try done; try (by (pose proof (Hx 0) as Hx0; inversion Hx0));
-    apply ora_order_orderN; auto.
+    try done; try (by (pose proof (Hx 0) as Hx0; inversion Hx0)); solve [apply ora_order_orderN; auto |
+    apply Hx, SIdx.inhabited].
   - intros [xl|xr|] [cxl|cxr|] [yl|yr|]; simpl in *;
       try destruct (pcore xl) as [cxl'|] eqn:Heq;
       try destruct (pcore xr) as [cxr'|] eqn:Heq;
@@ -231,37 +231,37 @@ Proof. intros ? [] ? EQ; inversion_clear EQ. by eapply oraid_free0_r. Qed.
 (* Qed. *)
 End ora.
 
-Arguments csumR : clear implicits.
+Arguments csumR {_} _ _.
 
 (* Functor *)
-#[export] Instance csum_map_ora_morphism {A A' B B' : ora} (f : A → A') (g : B → B') :
+#[export] Instance csum_map_ora_morphism {SI : sidx} {A A' B B' : ora} (f : A → A') (g : B → B') :
   OraMorphism f → OraMorphism g → OraMorphism (csum_map f g).
 Proof.
   split; try apply _.
   - intros n [a|b|] [a'|b'|]; simpl; try done;
         rewrite -?Cinl_orderN -?Cinr_orderN; by apply ora_morphism_orderN.
   - intros [a|b|]; rewrite /= -?Increasing_cinl -?Increasing_cinr => ?;
-      last apply Increasing_CsumBot; by apply ora_morphism_increasing.
+      last apply Increasing_CsumInvalid; by apply ora_morphism_increasing.
 Qed.
 
-Program Definition csumRF (Fa Fb : OrarFunctor) : OrarFunctor := {|
+Program Definition csumRF {SI : sidx} (Fa Fb : OrarFunctor) : OrarFunctor := {|
   orarFunctor_car A _ B _ := csumR (orarFunctor_car Fa A B) (orarFunctor_car Fb A B);
   orarFunctor_map A1 _ A2 _ B1 _ B2 _ fg := csumO_map (orarFunctor_map Fa fg) (orarFunctor_map Fb fg)
 |}.
 Next Obligation.
-  by intros Fa Fb A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply csumO_map_ne;
+  by intros ? Fa Fb A1 ? A2 ? B1 ? B2 ? n f g Hfg; apply csumO_map_ne;
     try apply orarFunctor_map_ne.
 Qed.
 Next Obligation.
-  intros Fa Fb A ? B ? x. rewrite /= -{2}(csum_map_id x).
+  intros ? Fa Fb A ? B ? x. rewrite /= -{2}(csum_map_id x).
   apply csum_map_ext=>y; apply orarFunctor_map_id.
 Qed.
 Next Obligation.
-  intros Fa Fb A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x. rewrite /= -csum_map_compose.
+  intros ? Fa Fb A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' x. rewrite /= -csum_map_compose.
   apply csum_map_ext=>y; apply orarFunctor_map_compose.
 Qed.
 
-#[export] Instance csumRF_contractive Fa Fb :
+#[export] Instance csumRF_contractive {SI : sidx} Fa Fb :
   OrarFunctorContractive Fa → OrarFunctorContractive Fb →
   OrarFunctorContractive (csumRF Fa Fb).
 Proof.

--- a/theories/algebra/view.v
+++ b/theories/algebra/view.v
@@ -8,7 +8,7 @@ From iris.prelude Require Import options.
 
 Section ora.
 
-  Context {A: ofe} {B : uora} (rel : view_rel A B).
+  Context {SI : sidx} {A: ofe} {B : uora} (rel : view_rel A B).
 
   Lemma view_validN_both : forall n (a : view rel), ✓{n} a -> ✓{n} view_auth_proj a ∧ ✓{n} view_frag_proj a.
   Proof.
@@ -116,22 +116,22 @@ instances of the functor structures [rFunctor] and [urFunctor]. Functors can
 only be defined for instances of [view], like [auth]. To make it more convenient
 to define functors for instances of [view], we define the map operation
 [view_map] and a bunch of lemmas about it. *)
-Definition view_map {A A' B B'}
-    {rel : nat → A → B → Prop} {rel' : nat → A' → B' → Prop}
+Definition view_map {SI : sidx} {A A' B B'}
+    {rel : SI → A → B → Prop} {rel' : SI → A' → B' → Prop}
     (f : A → A') (g : B → B') (x : view rel) : view rel' :=
   View (prod_map id (agree_map f) <$> view_auth_proj x) (g (view_frag_proj x)).
-Lemma view_map_id {A B} {rel : nat → A → B → Prop} (x : view rel) :
+Lemma view_map_id {SI : sidx} {A B} {rel : SI → A → B → Prop} (x : view rel) :
   view_map id id x = x.
 Proof. destruct x as [[[]|] ]; by rewrite // /view_map /= agree_map_id. Qed.
-Lemma view_map_compose {A A' A'' B B' B''}
-    {rel : nat → A → B → Prop} {rel' : nat → A' → B' → Prop}
-    {rel'' : nat → A'' → B'' → Prop}
+Lemma view_map_compose {SI : sidx} {A A' A'' B B' B''}
+    {rel : SI → A → B → Prop} {rel' : SI → A' → B' → Prop}
+    {rel'' : SI → A'' → B'' → Prop}
     (f1 : A → A') (f2 : A' → A'') (g1 : B → B') (g2 : B' → B'') (x : view rel) :
   view_map (f2 ∘ f1) (g2 ∘ g1) x
   =@{view rel''} view_map f2 g2 (view_map (rel':=rel') f1 g1 x).
 Proof. destruct x as [[[]|] ];  by rewrite // /view_map /= agree_map_compose. Qed.
-Lemma view_map_ext  {A A' B B' : ofe}
-    {rel : nat → A → B → Prop} {rel' : nat → A' → B' → Prop}
+Lemma view_map_ext {SI : sidx} {A A' B B' : ofe}
+    {rel : SI → A → B → Prop} {rel' : SI → A' → B' → Prop}
     (f1 f2 : A → A') (g1 g2 : B → B')
     `{!NonExpansive f1, !NonExpansive g1} (x : view rel) :
   (∀ a, f1 a ≡ f2 a) → (∀ b, g1 b ≡ g2 b) →
@@ -140,8 +140,8 @@ Proof.
   intros. constructor; simpl; [|by auto].
   apply option_fmap_equiv_ext=> a; by rewrite /prod_map /= agree_map_ext.
 Qed.
-Global Instance view_map_ne {A A' B B' : ofe}
-    {rel : nat → A → B → Prop} {rel' : nat → A' → B' → Prop}
+Global Instance view_map_ne {SI : sidx} {A A' B B' : ofe}
+    {rel : SI → A → B → Prop} {rel' : SI → A' → B' → Prop}
     (f : A → A') (g : B → B') `{Hf : !NonExpansive f, Hg : !NonExpansive g} :
   NonExpansive (view_map (rel':=rel') (rel:=rel) f g).
 Proof.
@@ -150,19 +150,19 @@ Proof.
   apply prod_map_ne; [done| |done]. by apply agree_map_ne.
 Qed.
 
-Definition viewO_map {A A' B B' : ofe}
-    {rel : nat → A → B → Prop} {rel' : nat → A' → B' → Prop}
+Definition viewO_map {SI : sidx} {A A' B B' : ofe}
+    {rel : SI → A → B → Prop} {rel' : SI → A' → B' → Prop}
     (f : A -n> A') (g : B -n> B') : viewO rel -n> viewO rel' :=
   OfeMor (view_map f g).
-Lemma viewO_map_ne {A A' B B' : ofe}
-    {rel : nat → A → B → Prop} {rel' : nat → A' → B' → Prop} :
+Lemma viewO_map_ne {SI : sidx} {A A' B B' : ofe}
+    {rel : SI → A → B → Prop} {rel' : SI → A' → B' → Prop} :
   NonExpansive2 (viewO_map (rel:=rel) (rel':=rel')).
 Proof.
   intros n f f' Hf g g' Hg [[[p ag]|] bf]; split=> //=.
   do 2 f_equiv. by apply agreeO_map_ne.
 Qed.
 
-Lemma view_map_cmra_morphism {A A' B B'}
+Lemma view_map_cmra_morphism {SI : sidx} {A A' B B'}
     {rel : view_rel A B} {rel' : view_rel A' B'}
     (f : A → A') (g : B → B') `{!NonExpansive f, !CmraMorphism g} :
   (∀ n a b, rel n a b → rel' n (f a) (g b)) →
@@ -180,9 +180,10 @@ Proof.
       try apply View_proper=> //=; by rewrite cmra_morphism_op.
 Qed.
 
-Lemma view_map_ora_morphism {A A'} {B B' : uora}
+Lemma view_map_ora_morphism {SI : sidx} {A A'} {B B' : uora}
     {rel : view_rel A B} {rel' : view_rel A' B'}
-    (Hrel : ∀n a x y, x ≼ₒ{n} y → rel n a y → rel n a x) (Hrel' : ∀n a x y, x ≼ₒ{n} y → rel' n a y → rel' n a x)
+    (Hrel : ∀n a x y, x ≼ₒ{n} y → rel n a y → rel n a x)
+    (Hrel' : ∀n a x y, x ≼ₒ{n} y → rel' n a y → rel' n a x)
     (f : A → A') (g : B → B') `{!NonExpansive f, !OraMorphism g} :
   (∀ n a b, rel n a b → rel' n (f a) (g b)) →
   OraMorphism(A := viewR rel Hrel)(B := viewR rel' Hrel') (view_map (rel:=rel) (rel':=rel') f g).

--- a/theories/algebra/view.v
+++ b/theories/algebra/view.v
@@ -8,7 +8,7 @@ From iris.prelude Require Import options.
 
 Section ora.
 
-  Context {A} {B : uora} (rel : view_rel A B).
+  Context {A: ofe} {B : uora} (rel : view_rel A B).
 
   Lemma view_validN_both : forall n (a : view rel), ✓{n} a -> ✓{n} view_auth_proj a ∧ ✓{n} view_frag_proj a.
   Proof.
@@ -50,7 +50,7 @@ Section ora.
       eapply (ora_extend(A := B)) in Hf as (f & ? & ?); last done.
       exists (View a f); destruct y; done.
     - intros ??? [??]; split; apply ora_dist_orderN; auto.
-    - intros ??? [??]; split; apply ora_orderN_S; auto.
+    - intros ???? [??]; split; eapply ora_orderN_le; eauto.
     - intros ???? [??] [??]; split; etrans; eauto.
     - intros ???? [??]; split; apply @ora_orderN_op; auto.
     - intros ???? [Ha Hf].

--- a/theories/logic/algebra.v
+++ b/theories/logic/algebra.v
@@ -60,7 +60,7 @@ Section excl.
   Lemma excl_equivI x y :
     x ≡ y ⊣⊢ match x, y with
                         | Excl a, Excl b => a ≡ b
-                        | ExclBot, ExclBot => True
+                        | ExclInvalid, ExclInvalid => True
                         | _, _ => False
                         end.
   Proof.
@@ -69,7 +69,7 @@ Section excl.
     - by destruct x, y; try constructor.
   Qed.
   Lemma excl_validI x :
-    ✓ x ⊣⊢ if x is ExclBot then False else True.
+    ✓ x ⊣⊢ if x is ExclInvalid then False else True.
   Proof. ouPred.unseal. by destruct x. Qed.
 End excl.
 
@@ -115,7 +115,7 @@ Section csum_ofe.
     x ≡ y ⊣⊢ match x, y with
                         | Cinl a, Cinl a' => a ≡ a'
                         | Cinr b, Cinr b' => b ≡ b'
-                        | CsumBot, CsumBot => True
+                        | CsumInvalid, CsumInvalid => True
                         | _, _ => False
                         end.
   Proof.
@@ -133,7 +133,7 @@ Section csum_ora.
     ✓ x ⊣⊢ match x with
                       | Cinl a => ✓ a
                       | Cinr b => ✓ b
-                      | CsumBot => False
+                      | CsumInvalid => False
                       end.
   Proof. ouPred.unseal. by destruct x. Qed.
 End csum_ora.

--- a/theories/logic/later_credits.v
+++ b/theories/logic/later_credits.v
@@ -186,7 +186,7 @@ Module le_upd.
     Proof.
       intros n; induction (lt_wf n) as [n _ IH].
       intros P1 P2 HP. rewrite (le_upd_unfold P1) (le_upd_unfold P2).
-      do 9 (done || f_equiv). f_contractive. eapply IH, dist_le; [lia|done|lia].
+      do 9 (done || f_equiv). f_contractive. eapply IH, dist_lt; done.
     Qed.
 
     Lemma bupd_le_upd P : (|==> P) ⊢ (|==£> P).

--- a/theories/logic/oupred.v
+++ b/theories/logic/oupred.v
@@ -1,4 +1,5 @@
 From iris.algebra Require Export updates.
+From iris.algebra Require Export stepindex_finite.
 From iris_ora.algebra Require Export ora.
 From iris.bi Require Export derived_connectives plainly internal_eq bi.
 From stdpp Require Import finite.
@@ -84,6 +85,7 @@ Section cofe.
       + intros P Q Q' HP HQ; split=> i x ??.
         by trans (Q i x);[apply HP|apply HQ].
     - intros n m P Q HPQ; split=> i x ??; apply HPQ; auto.
+      by trans m.
   Qed.
   Canonical Structure ouPredO : ofe := Ofe (ouPred M) ouPred_ofe_mixin.
 
@@ -91,12 +93,14 @@ Section cofe.
     {| ouPred_holds n x := ∀ n', n' ≤ n → ✓{n'}x → c n' n' x |}.
   Next Obligation.
     move=> /= c n1 n2 x1 x2 HP Hx12 Hn12 n3 Hn23 Hv. eapply ouPred_mono.
-    eapply HP, ora_validN_orderN, ora_orderN_le=>//; lia.
-    eapply ora_orderN_le=>//; lia. done.
+    eapply HP, ora_validN_orderN, ora_orderN_le=>//; try auto.
+    trans n2; try done.
+    eapply ora_orderN_le=>//. trans n2; done. done.
   Qed.
-  Global Program Instance ouPred_cofe : Cofe ouPredO := {| compl := ouPred_compl |}.
+  Global Program Instance ouPred_cofe : Cofe ouPredO := cofe_finite ouPred_compl _.
   Next Obligation.
-    intros n c; split=>i x Hin Hv.
+    intros n c.
+    split=>i x Hin Hv.
     etrans; [|by symmetry; apply (chain_cauchy c i n)]. split=>H; [by apply H|].
     repeat intro. apply (chain_cauchy c n' i)=>//. by eapply ouPred_mono.
   Qed.
@@ -162,8 +166,8 @@ Lemma ouPredO_map_ne {M1 M2 : uora} (f g : M2 -n> M1)
     `{!OraMorphism f, !OraMorphism g} n :
   f ≡{n}≡ g → ouPredO_map f ≡{n}≡ ouPredO_map g.
 Proof.
-  by intros Hfg P; split=> n' y ??;
-    rewrite /ouPred_holds /= (dist_le _ _ _ _(Hfg y)); last lia.
+  intros Hfg P; split=> n' y ??.
+    rewrite /ouPred_holds /= (dist_le _ _ _ _(Hfg y)); done.
 Qed.
 
 Program Definition ouPredOF (F : uorarFunctor) : oFunctor := {|
@@ -236,6 +240,7 @@ Next Obligation.
   apply HPQ; eauto.
   etrans; last apply Hle2.
   eapply ora_orderN_le; eauto.
+  trans n1'; done.
 Qed.
 Definition ouPred_impl_aux : seal (@ouPred_impl_def). by eexists. Qed.
 Definition ouPred_impl {M} := unseal ouPred_impl_aux M.
@@ -282,7 +287,9 @@ Program Definition ouPred_wand_def {M} (P Q : ouPred M) : ouPred M :=
 Next Obligation.
   intros M P Q n1 n1' x1 x1' HPQ ? Hn n3 x3 ???; simpl in *.
   eapply ouPred_mono with n3 (x1 ⋅ x3);
-    eauto using ora_validN_orderN, ora_monoN_r, ora_orderN_le.
+    eauto using HPQ, ora_validN_orderN, ora_monoN_r, ora_orderN_le.
+  apply HPQ; eauto.
+  eauto using ora_validN_orderN,  ora_monoN_r, ora_orderN_le.
 Qed.
 Definition ouPred_wand_aux : seal (@ouPred_wand_def). by eexists. Qed.
 Definition ouPred_wand {M} := unseal ouPred_wand_aux M.
@@ -311,7 +318,7 @@ Definition ouPred_persistently_eq :
 Program Definition ouPred_later_def {M} (P : ouPred M) : ouPred M :=
   {| ouPred_holds n x := match n return _ with 0 => True | S n' => P n' x end |}.
 Next Obligation.
-  intros M P [|n1] [|n2] x1 x2; eauto using ouPred_mono, ora_orderN_S with lia.
+  intros M P [|n1] [|n2] x1 x2; eauto using ouPred_mono, ora_orderN_le, SIdx.le_succ_diag_r with lia.
 Qed.
 Definition ouPred_later_aux : seal (@ouPred_later_def). by eexists. Qed.
 Definition ouPred_later {M} := unseal ouPred_later_aux M.
@@ -343,7 +350,7 @@ Local Program Definition ouPred_bupd_def {M} (Q : ouPred M) : ouPred M :=
       k ≤ n → ✓{k} (x ⋅ yf) → ∃ x', ✓{k} (x' ⋅ yf) ∧ Q k x' |}.
 Next Obligation.
   intros M Q n1 n2 x1 x2 HQ Hord Hn k yf Hk Hxy.
-  eapply ora_validN_orderN in Hxy; last by eapply ora_monoN_r, ora_orderN_le; [done | lia].
+  eapply ora_validN_orderN in Hxy; last eapply ora_monoN_r, ora_orderN_le; [|done|simpl; lia].
   auto.
 Qed.
 Local Definition ouPred_bupd_aux : seal (@ouPred_bupd_def). Proof. by eexists. Qed.
@@ -408,16 +415,16 @@ Proof.
     intros n P P' HP Q Q' HQ; split=> n' x ??.
     unseal; split; intros (x1&x2&?&?&?); ofe_subst;
       exists x1, x2; split_and!; try (apply HP || apply HQ); eauto.
-    + eapply (@cmra_validN_op_l M), ora_validN_orderN; eauto.
-    + eapply (@cmra_validN_op_r M), ora_validN_orderN; eauto.
-    + eapply (@cmra_validN_op_l M), ora_validN_orderN; eauto.
-    + eapply (@cmra_validN_op_r M), ora_validN_orderN; eauto.
+    + eapply (@cmra_validN_op_l _ M), ora_validN_orderN; eauto.
+    + eapply (@cmra_validN_op_r _ M), ora_validN_orderN; eauto.
+    + eapply (@cmra_validN_op_l _ M), ora_validN_orderN; eauto.
+    + eapply (@cmra_validN_op_r _ M), ora_validN_orderN; eauto.
   - (* NonExpansive2 ouPred_wand *)
     intros n P P' HP Q Q' HQ; split=> n' x ??.
     unseal; split; intros HPQ x' n'' ???;
       apply HQ, HPQ, HP; eauto.
-    + eapply (@cmra_validN_op_r M); eauto.
-    + eapply (@cmra_validN_op_r M); eauto.
+    + eapply (@cmra_validN_op_r _ M); eauto.
+    + eapply (@cmra_validN_op_r _ M); eauto.
   - (* φ → P ⊢ ⌜φ⌝ *)
     intros P φ ?. unseal; by split.
   - (* (φ → True ⊢ P) → ⌜φ⌝ ⊢ P *)
@@ -451,9 +458,9 @@ Proof.
     intros P P' Q Q' HQ HQ'; unseal.
     split; intros n' x ? (x1&x2&?&?&?); exists x1,x2; ofe_subst x; repeat split; eauto.
     + apply HQ; auto.
-      eapply (@cmra_validN_op_l M), ora_validN_orderN; eauto.
+      eapply (@cmra_validN_op_l _ M), ora_validN_orderN; eauto.
     + apply HQ'; auto.
-      eapply (@cmra_validN_op_r M), ora_validN_orderN; eauto.
+      eapply (@cmra_validN_op_r _ M), ora_validN_orderN; eauto.
   - (* P ⊢ emp ∗ P *)
     intros P. rewrite /ouPred_emp. unseal; split=> n x ?? /=.
     exists (core x), x. rewrite ora_core_l; repeat split; auto.
@@ -480,7 +487,7 @@ Proof.
     apply HPQR in HP.
     apply HP in HQ; eauto using ora_validN_orderN.
     eauto using ouPred_mono.
-    { eapply (@cmra_validN_op_l M), ora_validN_orderN; eauto. }
+    { eapply (@cmra_validN_op_l _ M), ora_validN_orderN; eauto. }
 Qed.
 
 Lemma ouPred_bi_persistently_mixin (M : uora) :
@@ -540,7 +547,7 @@ Proof.
     exists y1, y2; split; auto; by rewrite Hy1 Hy2.
   - (* ▷ P ∗ ▷ Q ⊢ ▷ (P ∗ Q) *)
     intros P Q. unseal; split=> -[|n] x ? /=; [done|intros (x1&x2&Hx&?&?)].
-    exists x1, x2; eauto using ora_orderN_S.
+    exists x1, x2. split; eauto. eapply ora_orderN_le; eauto. simpl; lia.
   - (* ▷ bi_persistently P ⊢ bi_persistently (▷ P) *)
     by unseal.
   - (* bi_persistently (▷ P) ⊢ ▷ bi_persistently P *)
@@ -563,7 +570,7 @@ Notation "✓ x" := (ouPred_ora_valid x) (at level 20) : bi_scope.
 Global Instance later_contractive M : Contractive (bi_later (PROP:=ouPredI M)).
 Proof.
   unseal; intros [|n] P Q HPQ; split=> -[|n'] x ?? //=; try lia.
-  eapply HPQ, (cmra_validN_S(A:=M)); auto.
+  eapply HPQ, (cmra_validN_S(A:=M)); auto. simpl; lia.
 Qed.
 
 Global Instance ouPred_later_contractive M : BiLaterContractive (ouPredI M).
@@ -574,13 +581,13 @@ Qed.
 Lemma later_eq_1 M {A : ofe} (x y : A) : ouPred_internal_eq(M := M) (Next x) (Next y) ⊢ ▷ (ouPred_internal_eq x y).
 Proof.
   unseal. split. intros [|n]; simpl; [done|].
-  intros ?? Heq; apply Heq; auto.
+  intros ?? Heq; apply Heq; auto. simpl; lia.
 Qed.
 Lemma later_eq_2 M {A : ofe} (x y : A) : ▷ (ouPred_internal_eq(M := M) x y) ⊢ ouPred_internal_eq (Next x) (Next y).
 Proof.
   unseal. split. intros n ? ? Hn; split; intros m Hlt; simpl in *.
   destruct n as [|n]; first lia.
-  eauto using dist_le with si_solver.
+  eapply dist_le; eauto. simpl; lia.
 Qed.
 
 Lemma ouPred_bi_internal_eq_mixin M :
@@ -683,7 +690,7 @@ Hint Immediate ouPred_in_entails : core.
 Global Instance ownM_ne : NonExpansive (@ouPred_ownM M).
 Proof.
   intros n a b Ha.
-  unseal; split=> n' x ? /=. by rewrite (dist_le _ _ _ _ Ha); last lia.
+  unseal; split=> n' x ? /=. rewrite (dist_le _ _ _ _ Ha) //.
 Qed.
 Global Instance ownM_proper: Proper ((≡) ==> (⊣⊢)) (@ouPred_ownM M) := ne_proper _.
 
@@ -691,7 +698,7 @@ Global Instance ora_valid_ne {A : ora} :
   NonExpansive (@ouPred_ora_valid M A).
 Proof.
   intros n a b Ha; unseal; split=> n' x ? /=.
-  by rewrite (dist_le _ _ _ _ Ha); last lia.
+  rewrite (dist_le _ _ _ _ Ha) //.
 Qed.
 Global Instance ora_valid_proper {A : ora} :
   Proper ((≡) ==> (⊣⊢)) (@ouPred_ora_valid M A) := ne_proper _.
@@ -717,7 +724,7 @@ Lemma entails_lim (cP cQ : chain (ouPredO M)) :
   (∀ n, cP n ⊢ cQ n) → compl cP ⊢ compl cQ.
 Proof.
   intros Hlim; split=> n m ? HP.
-  eapply ouPred_holds_ne, Hlim, HP; rewrite ?conv_compl; eauto.
+  eapply ouPred_holds_ne, Hlim; eauto. rewrite ?conv_compl; eauto.
 Qed.
 
 (** Basic update modality *)
@@ -726,25 +733,26 @@ Notation "|==> P" := (ouPred_bupd P) : bi_scope.
 Lemma bupd_intro P : P ⊢ |==> P.
 Proof.
   unseal. split=> n x ? HP k yf ?; exists x; split; first done.
-  apply ouPred_mono with n x; eauto using (cmra_validN_op_l(A:=M)).
+  apply ouPred_mono with n x; eauto using cmra_validN.
 Qed.
 Lemma bupd_mono P Q : (P ⊢ Q) → (|==> P) ⊢ |==> Q.
 Proof.
   unseal. intros HPQ; split=> n x ? HP k yf ??.
   destruct (HP k yf) as (x'&?&?); eauto.
   exists x'; split; eauto.
-  eapply ouPred_in_entails; eauto. eapply (cmra_validN_op_l(A:=M)); eauto.
+  eapply ouPred_in_entails; eauto.
+  eapply (cmra_validN_op_l(A:=M)); eauto.
 Qed.
 Lemma bupd_trans P : (|==> |==> P) ⊢ |==> P.
 Proof. unseal; split; naive_solver. Qed.
 Lemma bupd_frame_r P R : (|==> P) ∗ R ⊢ |==> P ∗ R.
 Proof.
   unseal; split; intros n x ? (x1&x2&Hx&HP&?) k yf ??.
-  eapply ora_validN_orderN in H2; last by eapply ora_monoN_r, ora_orderN_le; [done | lia].
+  eapply ora_validN_orderN in H2; last by eapply ora_monoN_r, ora_orderN_le; [done | simpl; lia].
   destruct (HP k (x2 ⋅ yf)) as (x'&?&?); eauto.
   { by rewrite assoc. }
   exists (x' ⋅ x2); split; first by rewrite -assoc.
-  exists x', x2. eauto using ouPred_mono, (cmra_validN_op_l(A:=M)), cmra_validN_op_r.
+  exists x', x2. eauto using ouPred_mono, cmra_validN_op_l, cmra_validN_op_r.
 Qed.
 Lemma bupd_plainly P : (|==> ■ P) ⊢ ■ P.
 Proof.
@@ -801,7 +809,7 @@ Lemma bupd_ownM_updateP x (Φ : M → Prop) :
   cmra_updateP(A := uora_oraR M) x Φ → ouPred_ownM x ⊢ |==> ∃ y, ⌜Φ y⌝ ∧ ouPred_ownM y.
 Proof.
   unseal=> Hup; split=> n x2 ? /= Hx k yf ? Hxy.
-  eapply ora_validN_orderN in Hxy; last (eapply ora_monoN_r, ora_orderN_le; [done | lia]).
+  eapply ora_validN_orderN in Hxy; last (eapply ora_monoN_r, ora_orderN_le; [done | simpl; lia]).
   destruct (Hup k (Some yf)) as (y&?&?); simpl in *; first done.
   eauto.
 Qed.
@@ -819,7 +827,7 @@ Lemma ora_valid_intro {A : ora} (a : A) :
 Proof. unseal=> ?; split=> n x ? _ /=; by apply cmra_valid_validN. Qed.
 Lemma ora_valid_elim {A : ora} (a : A) : ¬ ✓{0} a → ✓ a ⊢ (False : ouPred M).
 Proof.
-  intros Ha. unseal. split=> n x ??; apply Ha, cmra_validN_le with n; auto.
+  intros Ha. unseal. split=> n x ??; apply Ha, cmra_validN_le with n; simpl; auto.
 Qed.
 Lemma plainly_ora_valid_1 {A : ora} (a : A) : ✓ a ⊢ plainly (✓ a : ouPred M).
 Proof. by unseal. Qed.

--- a/theories/logic/weakestpre.v
+++ b/theories/logic/weakestpre.v
@@ -125,7 +125,7 @@ Proof.
   (* FIXME : simplify this proof once we have a good definition and a
      proper instance for step_fupdN. *)
   induction num_laters_per_step as [|k IHk]; simpl; last by rewrite IHk.
-  rewrite IH; [done|lia|]. intros v. eapply dist_le; [apply HΦ|lia].
+  rewrite IH; [done..|]. intros v. eapply dist_lt; [apply HΦ|done].
 Qed.
 Global Instance wp_proper s E e :
   Proper (pointwise_relation _ (≡) ==> (≡)) (wp (PROP:=iProp Σ) s E e).


### PR DESCRIPTION
This PR aims to support Iris 4.4.0.
Should probably follow the changes in [this commit](https://gitlab.mpi-sws.org/iris/iris/-/commit/f8ea942308c63a8df1ec7b4fb38db3ad6c5d3c86) in the Iris repo. The main change is the parametrization of step indexes.