### PR TITLE
Fix some warnings and delete redundant lemmas.

### DIFF
--- a/theories/algebra/agree.v
+++ b/theories/algebra/agree.v
@@ -1,7 +1,5 @@
 From iris.algebra Require Import agree.
 From iris_ora.algebra Require Export ora.
-(* From iris_ora.algebra Require Import list. *)
-From iris_ora.logic Require Import oupred.
 Local Arguments validN _ _ _ !_ /.
 Local Arguments valid _ _  !_ /.
 Local Arguments op _ _ _ !_ /.
@@ -161,18 +159,6 @@ Proof.
   by rewrite -EQy -EQz -Hx'y' -Hx'z'.
 Qed.
 
-(** Internalized properties *)
-Lemma agree_equivI {M} a b : to_agree a ≡ to_agree b ⊣⊢ (a ≡ b : ouPred M).
-Proof.
-  rewrite /internal_eq /bi_internal_eq_internal_eq /=. ouPred.unseal. do 2 split.
-  - intros Hx. exact: to_agree_injN.
-  - intros Hx. exact: to_agree_ne.
-Qed.
-Lemma agree_validI {M} x y : ✓ (x ⋅ y) ⊢ (x ≡ y : ouPred M).
-Proof.
-  rewrite /internal_eq /bi_internal_eq_internal_eq /=.
-  ouPred.unseal; split=> r n _ ?; by apply: agree_op_invN.
-Qed.
 End agree.
 
 Arguments agreeR : clear implicits.

--- a/theories/algebra/ora.v
+++ b/theories/algebra/ora.v
@@ -100,7 +100,7 @@ Add Printing Constructor ora.
 #[export] Hint Extern 0 (OraOrderN _) => eapply (@ora_orderN _) : typeclass_instances.
 Coercion ora_ofeO (A : ora) : ofe := Ofe A (ora_ofe_mixin A).
 Canonical Structure ora_ofeO.
-Coercion ora_cmraR (A : ora) : cmra := Cmra A (ora_cmra_mixin A).
+Coercion ora_cmraR (A : ora) : cmra := Cmra' A (ora_ofe_mixin A) (ora_cmra_mixin A).
 Canonical Structure ora_cmraR.
 
 Definition ora_mixin_of' A {Ac : ora} (f : Ac → A) : OraMixin Ac := ora_mixin Ac.

--- a/theories/algebra/ora.v
+++ b/theories/algebra/ora.v
@@ -869,7 +869,7 @@ Record OrarFunctor := OraRFunctor {
 #[export] Instance: Params (@orarFunctor_map) 5 := {}.
 
 Declare Scope orarFunctor_scope.
-Delimit Scope orarFunctor_scope with RF.
+Delimit Scope orarFunctor_scope with ORF.
 Bind Scope orarFunctor_scope with rFunctor.
 
 Class OrarFunctorContractive (F : OrarFunctor) :=
@@ -906,7 +906,7 @@ Record uorarFunctor := UOraRFunctor {
 #[export] Instance: Params (@uorarFunctor_map) 5 := {}.
 
 Declare Scope uorarFunctor_scope.
-Delimit Scope uorarFunctor_scope with URF.
+Delimit Scope uorarFunctor_scope with UORF.
 Bind Scope uorarFunctor_scope with uorarFunctor.
 
 Class uorarFunctorContractive (F : uorarFunctor) :=
@@ -1350,7 +1350,7 @@ Next Obligation.
   intros F1 F2 A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' [??]; simpl.
   by rewrite !orarFunctor_map_compose.
 Qed.
-Notation "F1 * F2" := (prodRF F1%RF F2%RF) : rFunctor_scope.
+Notation "F1 * F2" := (prodRF F1%ORF F2%ORF) : rFunctor_scope.
 
 #[export] Instance prodRF_contractive F1 F2 :
   OrarFunctorContractive F1 → OrarFunctorContractive F2 →
@@ -1373,7 +1373,7 @@ Next Obligation.
   intros F1 F2 A1 ? A2 ? A3 ? B1 ? B2 ? B3 ? f g f' g' [??]; simpl.
   by rewrite !uorarFunctor_map_compose.
 Qed.
-Notation "F1 * F2" := (prodURF F1%URF F2%URF) : urFunctor_scope.
+Notation "F1 * F2" := (prodURF F1%UORF F2%UORF) : urFunctor_scope.
 
 #[export] Instance prodURF_contractive F1 F2 :
   uorarFunctorContractive F1 → uorarFunctorContractive F2 →

--- a/theories/logic/oupred.v
+++ b/theories/logic/oupred.v
@@ -56,12 +56,12 @@ Record ouPred (M : uora) : Type := IProp {
   ouPred_mono n1 n2 x1 x2 :
     ouPred_holds n1 x1 → x1 ≼ₒ{n1} x2 → n2 ≤ n1 → ouPred_holds n2 x2
 }.
+
+Bind Scope bi_scope with ouPred.
 Arguments ouPred_holds {_} _ _ _ : simpl never.
 Add Printing Constructor ouPred.
 #[export] Instance: Params (@ouPred_holds) 3 := {}.
 
-Bind Scope bi_scope with ouPred.
-Arguments ouPred_holds {_} _%I _ _.
 
 Section cofe.
   Context {M : uora}.


### PR DESCRIPTION
Fixed one projection-no-head-constant warning in ora; not sure how to fix the other warnings of the same kind. They don't seem to cause any problem at the moment.
Warnings related to this might be caused by the smart constructor in the [`Ora` notation](https://github.com/rinshankaihou/ora/blob/178236131f1246c650fce76ec9f12a42f5714bf2/theories/algebra/ora.v#L80) not being fully evaluated when the type argument `A` is quantified.
